### PR TITLE
Add a main attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest",
     "tsc:no-emit": "tsc --noEmit --noErrorTruncation --pretty"
   },
+  "main": "./dist/index.cjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
This will help e.g. Metro find the built package.