### PR TITLE
Export everything from the main module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: ci
 on:
-    pull_request:
-      branches:
-        - main
-    
+  pull_request:
+    branches:
+      - main
+
 jobs:
   lint-type-check-and-test:
     runs-on: ubuntu-22.04
@@ -14,7 +14,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'yarn'
-          cache-dependency-path: yarn.lock
       - name: Install yarn dependencies
         run: yarn install --frozen-lockfile
       - name: Type check

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,6 +68,7 @@ export {
   type UseFormReturn,
   type UseFormSetValue,
 } from './use-form';
+export * as validation from './validation';
 
 // -----------------------------------------------------------------------------
 // propsWithControlAreEqual

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -2,7 +2,7 @@
  * Helpers for constructing validation functions for common cases.
  */
 
-import {FieldError, NO_FIELD_ERRORS} from '.';
+import {FieldError, NO_FIELD_ERRORS} from './field-errors';
 
 type ValueMessage<T> = {
   value: T;


### PR DESCRIPTION
React Native does not yet support exports by default so we need a way for React Native users to import the whole library. In the future we might export smaller parts of the library under e.g. /core or /validation for users that don't want or need the whole library.