### PR TITLE
Fix: remove right element in useFieldArray remove

### DIFF
--- a/src/__tests__/use-field-array.test.tsx
+++ b/src/__tests__/use-field-array.test.tsx
@@ -278,7 +278,7 @@ describe('FieldArray', () => {
     });
   });
 
-  describe('setState', () => {
+  describe('setValue', () => {
     it('updates value on same length value', async () => {
       render(<ArrayTest setValueValue={['1']} />);
 
@@ -373,17 +373,17 @@ describe('FieldArray', () => {
 
       await user.click(screen.getByRole('button', {name: 'set value'}));
 
-      expect(screen.getByTestId('input-0')).toHaveValue('1');
-      expect(screen.getByText('Form: ["1"]')).toBeTruthy();
+      expect(screen.getByText('Field 0 dirty')).toBeTruthy();
+      expect(screen.getByText('Form dirty')).toBeTruthy();
     });
 
     it('updates row valid state', async () => {
-      render(<ArrayTest initialValue={['']} setValueValue={['1']} />);
+      render(<ArrayTest initialValue={['1']} setValueValue={['']} />);
 
       await user.click(screen.getByRole('button', {name: 'set value'}));
 
-      expect(screen.getByTestId('input-0')).toHaveValue('1');
-      expect(screen.getByText('Form: ["1"]')).toBeTruthy();
+      expect(screen.getByText('Field 0 errors: Required')).toBeTruthy();
+      expect(screen.queryByText('Form valid')).toBeNull();
     });
 
     it('removes row', async () => {
@@ -394,6 +394,20 @@ describe('FieldArray', () => {
       );
 
       expect(screen.getByText('Form: []')).toBeTruthy();
+    });
+
+    it('removes the correct row', async () => {
+      render(<ArrayTest initialValue={[]} />);
+
+      await user.click(screen.getByRole('button', {name: 'add row'}));
+      await user.type(screen.getByTestId('input-0'), '1');
+      await user.click(screen.getByRole('button', {name: 'add row'}));
+      await user.type(screen.getByTestId('input-1'), '2');
+      await user.click(screen.getByRole('button', {name: 'remove row 0'}));
+
+      expect(screen.queryByTestId('input-1')).toBeNull();
+      expect(screen.getByTestId('input-0')).toHaveValue('2');
+      expect(screen.getByText('Form: ["2"]')).toBeTruthy();
     });
 
     it('marks dirty if longer than initial', async () => {
@@ -424,17 +438,33 @@ describe('FieldArray', () => {
   });
 
   describe('reset', () => {
-    it('resets', async () => {
+    it('resets to initial value', async () => {
       render(<ArrayTest />);
 
       await user.type(screen.getByTestId('input-0'), '1');
       await user.click(screen.getByRole('button', {name: 'reset'}));
 
       expect(screen.getByTestId('input-0')).toHaveValue('');
+      expect(screen.getByText('Form: [""]')).toBeTruthy();
+    });
+
+    it('resets to clean state', async () => {
+      render(<ArrayTest />);
+
+      await user.type(screen.getByTestId('input-0'), '1');
+      await user.click(screen.getByRole('button', {name: 'reset'}));
+
       expect(screen.queryByText('Field 0 dirty')).toBeNull();
       expect(screen.queryByText('Form dirty')).toBeNull();
+    });
 
-      // A reset form should be valid:
+    it('resets to valid state', async () => {
+      render(<ArrayTest initialValue={['1']} resetNewInitialValue={['']} />);
+
+      // Make the field invalid:
+      await user.clear(screen.getByTestId('input-0'));
+      await user.click(screen.getByRole('button', {name: 'reset'}));
+
       expect(screen.queryByText('Field 0 errors: Required')).toBeNull();
       expect(screen.queryByText('Form valid')).toBeTruthy();
       expect(screen.queryByText('Form errors: Required')).toBeNull();

--- a/src/__tests__/use-field-object.test.tsx
+++ b/src/__tests__/use-field-object.test.tsx
@@ -190,7 +190,7 @@ describe('FieldObject', () => {
     });
   });
 
-  describe('setState', () => {
+  describe('setValue', () => {
     it('updates value', async () => {
       render(<ObjectTest />);
 
@@ -240,17 +240,32 @@ describe('FieldObject', () => {
   });
 
   describe('reset', () => {
-    it('resets', async () => {
+    it('resets to initial value', async () => {
       render(<ObjectTest />);
 
       await user.type(screen.getByTestId('input-a'), '1');
       await user.click(screen.getByRole('button', {name: 'reset'}));
 
       expect(screen.getByTestId('input-a')).toHaveValue('');
+      expect(screen.getByText('Form: {"a":"","b":""}')).toBeTruthy();
+    });
+
+    it('resets to clean state', async () => {
+      render(<ObjectTest />);
+
+      await user.type(screen.getByTestId('input-a'), '1');
+      await user.click(screen.getByRole('button', {name: 'reset'}));
+
       expect(screen.queryByText('Field a dirty')).toBeNull();
       expect(screen.queryByText('Form dirty')).toBeNull();
+    });
 
-      // A reset form should be valid:
+    it('resets to valid state', async () => {
+      render(<ObjectTest initialValue={{a: '1', b: ''}} />);
+
+      await user.clear(screen.getByTestId('input-a'));
+      await user.click(screen.getByRole('button', {name: 'reset'}));
+
       expect(screen.queryByText('Field a errors: Required')).toBeNull();
       expect(screen.getByText('Form valid')).toBeTruthy();
       expect(screen.queryByText('Form errors: Required')).toBeNull();

--- a/src/control.ts
+++ b/src/control.ts
@@ -102,4 +102,7 @@ export type Control<T> = {
 
   /** See {@link UseFormProps.mode} */
   validationMode: 'onBlur' | 'onChange';
+
+  /** The current value of the child field in the form. */
+  value: T;
 };


### PR DESCRIPTION
The core of the issue is due to how React handles child components. Take the following example:

```tsx
<div>
  {[1,2].map((_, index) => (
    <MyInput key={index} />
  ))}
</div>
```

where `MyInput` is a stateful component.

No matter which element (i.e. 1 or 2) we remove of the array the first rendered element will remain, as it will have index 0 in both cases. Removing the `key` prop altogether still causes the last element to be removed.

In the useFieldArray this has the effect that removing any element actually ends up removing the last element. This isn't a bug in `useFieldArray` per se (i.e. it does remove the right element from its internal arrays) but rather an issue of its children (e.g. components using `useField`) being stateful.

We could try to hack around this somehow by creating some internal, unique key props to try to convince React to remove the child component we want but that's brittle.

The key issue here is that all the hooks (e.g. `useField` and `useForm`) have their own copy of the state (and thus they are all stateful). `useField` just doesn't care if e.g. `useFieldArray` changes its state (by removing an element). This is by design as the design is to have state changes flow "upward" from `useField` towards `useForm`. However in the case of `remove` we actually need state to also flow "downwards".

The solution here is to simply not have copies of the state and only have `useForm` own the form state. In that way there are no state in the `useField` (at least as far as the form value is concerned) and thus changing the state by e.g. removing an array element will be reflected correctly in the children.