### PR TITLE
Switch to Yarn prepack lifecycle hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "yarn clean && rollup -c",
     "clean": "rm -rf dist/* || true",
     "lint": "eslint .",
-    "prepare": "yarn build",
+    "prepack": "yarn build",
     "test": "jest",
     "tsc:no-emit": "tsc --noEmit --noErrorTruncation --pretty"
   },


### PR DESCRIPTION
The prepare hook no longer exists:
https://yarnpkg.com/advanced/lifecycle-scripts