### PR TITLE
Fix: reset non-dirty values to new initial value when keepDirtyValues

### DIFF
--- a/src/__tests__/use-field-object.test.tsx
+++ b/src/__tests__/use-field-object.test.tsx
@@ -50,7 +50,7 @@ const ObjectTest = ({
       </div>
       <button onClick={() => reset(resetNewInitialValue)} title="reset" />
       <button
-        onClick={() => reset(undefined, {keepDirtyValues: true})}
+        onClick={() => reset(resetNewInitialValue, {keepDirtyValues: true})}
         title="reset non-dirty"
       />
       <button
@@ -256,13 +256,16 @@ describe('FieldObject', () => {
     });
 
     it('can keep dirty value', async () => {
-      render(<ObjectTest />);
+      render(<ObjectTest resetNewInitialValue={{a: '2', b: '3'}} />);
 
       await user.type(screen.getByTestId('input-a'), '1');
       await user.click(screen.getByRole('button', {name: 'reset non-dirty'}));
 
       expect(screen.getByTestId('input-a')).toHaveValue('1');
       expect(screen.getByText('Field a dirty')).toBeTruthy();
+      expect(screen.getByTestId('input-b')).toHaveValue('3');
+      expect(screen.queryByText('Field b dirty')).toBeNull();
+      expect(screen.getByText('Form: {"a":"1","b":"3"}')).toBeTruthy();
       expect(screen.getByText('Form dirty')).toBeTruthy();
     });
   });

--- a/src/control.ts
+++ b/src/control.ts
@@ -14,7 +14,14 @@ export type ControlOnChange<T> = (
 ) => void;
 
 export type ResetOptions = {
-  /** If true keep values in fields that were dirty before the reset. */
+  /**
+   * If `true`, don't reset dirty fields' `value` and `errors`.
+   *
+   * The field's `initialValue` will still be reset. If the `initialValue` is
+   * different from the current `value` the field will be marked as dirty.
+   *
+   * Kept values also keep their errors.
+   */
   keepDirtyValues: boolean;
 };
 
@@ -42,9 +49,13 @@ export type FieldRef<T> = {
   /**
    * Reset the field and any child fields to their initial value.
    *
+   * Reset fields have no errors, just like when the form is first created.
+   *
    * If `value` is provided, the initial value is first set to `value`.
+   *
+   * @returns The new value of the field.
    */
-  reset: (value?: T, options?: ResetOptions) => void;
+  reset: (value?: T, options?: ResetOptions) => T;
 
   /**
    * Set the value of the field.

--- a/src/use-field.ts
+++ b/src/use-field.ts
@@ -1,6 +1,11 @@
 import React from 'react';
 
-import {Control, FieldRefSetValue, SetValueOptions} from './control';
+import {
+  Control,
+  FieldRefSetValue,
+  ResetOptions,
+  SetValueOptions,
+} from './control';
 import {
   FieldError,
   fieldErrorSetsDeepEqual,
@@ -176,9 +181,17 @@ export const useField = <T>({
     });
   });
 
-  const reset = React.useCallback(() => {
-    setErrors(NO_FIELD_ERRORS);
-  }, []);
+  const reset = React.useCallback(
+    (newValue: T = initialValue, options?: ResetOptions) => {
+      const {keepDirtyValues = false} = options || {};
+      const keepValue = keepDirtyValues && isDirty;
+      if (!keepValue) {
+        setErrors(NO_FIELD_ERRORS);
+      }
+      return keepValue ? value : newValue;
+    },
+    [initialValue, isDirty, value],
+  );
 
   const validateMethod = React.useCallback(
     () => validateAndSetErrors(value),

--- a/src/use-form.ts
+++ b/src/use-form.ts
@@ -211,15 +211,11 @@ export const useForm = <T>({
   const reset = useEventCallback((newValue?: T, options?: ResetOptions) => {
     setIsSubmitted(false);
     setIsSubmitSuccessful(false);
-    const {keepDirtyValues = false} = options || {};
     if (newValue !== undefined) {
       setInitialValue(newValue);
     }
-    const keepValue = keepDirtyValues && isDirty;
-    if (!keepValue) {
-      setValue(newValue ?? initialValue);
-    }
-    ref.current?.reset(newValue, options);
+    const updatedValue = ref.current?.reset(newValue, options) ?? initialValue;
+    setValue(updatedValue);
   });
 
   const formState = React.useMemo(


### PR DESCRIPTION
If a field is non-dirty it should be reset to the new initial value.