### PR TITLE
Use react refs to correctly apply multiple form state updates

### DIFF
--- a/src/__tests__/repro.test.tsx
+++ b/src/__tests__/repro.test.tsx
@@ -12,7 +12,51 @@ const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
 
 /** This test contains repros for bugs that have appeared in the wild. */
 describe('repros', () => {
-  // TODO(tibbe): Figure out if we can express this as a property in the regulat
+  it('consecutive sibling setValue updates applied together on the next rerender', async () => {
+    const Form = () => {
+      const {control, setValue, value} = useForm({
+        initialValue: {name: {first: '', last: ''}},
+      });
+
+      const {fields} = useFieldObject({control});
+      const {fields: nameFields} = useFieldObject({
+        control: fields.name.control,
+      });
+
+      return (
+        <div>
+          <TextField name="first" parentControl={nameFields.first.control} />
+          <TextField name="last" parentControl={nameFields.last.control} />
+          <button
+            onClick={() => {
+              setValue(prev => ({
+                ...prev,
+                name: {...prev.name, first: 'Ada'},
+              }));
+              setValue(prev => ({
+                ...prev,
+                name: {...prev.name, last: 'Lovelace'},
+              }));
+            }}
+            title="set full name"
+          />
+          <p>Form: {JSON.stringify(value)}</p>
+        </div>
+      );
+    };
+
+    render(<Form />);
+
+    await user.click(screen.getByRole('button', {name: 'set full name'}));
+
+    expect(screen.getByTestId('input-first')).toHaveValue('Ada');
+    expect(screen.getByTestId('input-last')).toHaveValue('Lovelace');
+    expect(
+      screen.getByText('Form: {"name":{"first":"Ada","last":"Lovelace"}}'),
+    ).toBeTruthy();
+  });
+
+  // TODO(tibbe): Figure out if we can express this as a property in the regular
   // use-field-array.test.tsx file.
   it('onChangeItem propagates dirty state and errors', async () => {
     const Form = () => {

--- a/src/__tests__/repro.test.tsx
+++ b/src/__tests__/repro.test.tsx
@@ -4,7 +4,7 @@ import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
-import {useFieldArray, useForm, useFieldObject} from '..';
+import {NO_FIELD_ERRORS, useFieldArray, useForm, useFieldObject} from '..';
 import TextField from '../test-helpers/TextField';
 
 jest.useFakeTimers();
@@ -51,6 +51,48 @@ describe('repros', () => {
 
     expect(screen.getByTestId('input-first')).toHaveValue('Ada');
     expect(screen.getByTestId('input-last')).toHaveValue('Lovelace');
+    expect(
+      screen.getByText('Form: {"name":{"first":"Ada","last":"Lovelace"}}'),
+    ).toBeTruthy();
+  });
+
+  it('preserves both sibling child onChange updates in the same tick', async () => {
+    const Form = () => {
+      const {control, value} = useForm({
+        initialValue: {name: {first: '', last: ''}},
+      });
+
+      const {fields} = useFieldObject({control});
+      const {fields: nameFields} = useFieldObject({
+        control: fields.name.control,
+      });
+
+      return (
+        <div>
+          <button
+            onClick={() => {
+              nameFields.first.control.onChange('Ada', {
+                isDirty: true,
+                errors: NO_FIELD_ERRORS,
+              });
+              nameFields.last.control.onChange('Lovelace', {
+                isDirty: true,
+                errors: NO_FIELD_ERRORS,
+              });
+            }}
+            title="child sibling updates"
+          />
+          <p>Form: {JSON.stringify(value)}</p>
+        </div>
+      );
+    };
+
+    render(<Form />);
+
+    await user.click(
+      screen.getByRole('button', {name: 'child sibling updates'}),
+    );
+
     expect(
       screen.getByText('Form: {"name":{"first":"Ada","last":"Lovelace"}}'),
     ).toBeTruthy();

--- a/src/__tests__/repro.test.tsx
+++ b/src/__tests__/repro.test.tsx
@@ -98,6 +98,46 @@ describe('repros', () => {
     ).toBeTruthy();
   });
 
+  it('preserves both sibling array child onChange updates in the same tick', async () => {
+    const Form = () => {
+      const {control, value} = useForm({
+        initialValue: {rows: ['', '']},
+      });
+
+      const {fields: recordFields} = useFieldObject({control});
+      const {fields} = useFieldArray({
+        control: recordFields.rows.control,
+      });
+
+      return (
+        <div>
+          <button
+            onClick={() => {
+              fields[0].control.onChange('Ada', {
+                isDirty: true,
+                errors: NO_FIELD_ERRORS,
+              });
+              fields[1].control.onChange('Lovelace', {
+                isDirty: true,
+                errors: NO_FIELD_ERRORS,
+              });
+            }}
+            title="array child sibling updates"
+          />
+          <p>Form: {JSON.stringify(value)}</p>
+        </div>
+      );
+    };
+
+    render(<Form />);
+
+    await user.click(
+      screen.getByRole('button', {name: 'array child sibling updates'}),
+    );
+
+    expect(screen.getByText('Form: {"rows":["Ada","Lovelace"]}')).toBeTruthy();
+  });
+
   // TODO(tibbe): Figure out if we can express this as a property in the regular
   // use-field-array.test.tsx file.
   it('onChangeItem propagates dirty state and errors', async () => {

--- a/src/__tests__/use-field-array.test.tsx
+++ b/src/__tests__/use-field-array.test.tsx
@@ -646,6 +646,24 @@ describe('FieldArray', () => {
 
       expect(screen.getByText('Form dirty')).toBeTruthy();
     });
+
+    it('keeps retained dirty row errors after updating a sibling row', async () => {
+      // Start with two valid rows.
+      render(<ArrayTest initialValue={['1', '2']} />);
+
+      // Clear row 0 -> row 0 is now dirty and invalid.
+      await user.clear(screen.getByTestId('input-0'));
+
+      // Row 0 dirty bit should be retained even after reset non-dirty.
+      await user.click(screen.getByRole('button', {name: 'reset non-dirty'}));
+      expect(screen.getByText('Form errors: Required')).toBeTruthy();
+
+      // Update row 1 -> row 0 dirty bit should still be retained.
+      await user.type(screen.getByTestId('input-1'), '3');
+
+      expect(screen.getByText('Field 0 errors: Required')).toBeTruthy();
+      expect(screen.getByText('Form errors: Required')).toBeTruthy();
+    });
   });
 
   describe('validate', () => {

--- a/src/__tests__/use-field-object.test.tsx
+++ b/src/__tests__/use-field-object.test.tsx
@@ -290,6 +290,24 @@ describe('FieldObject', () => {
       expect(screen.queryByText('Form valid')).toBeNull();
       expect(screen.getByText('Form errors: Required')).toBeTruthy();
     });
+
+    it('keeps retained dirty child errors after updating a sibling', async () => {
+      // Start with two valid objects.
+      render(<ObjectTest initialValue={{a: '1', b: '2'}} />);
+
+      // Clear object 0 -> object 0 is now dirty and invalid.
+      await user.clear(screen.getByTestId('input-a'));
+
+      // Object 0 dirty bit should be retained even after reset non-dirty.
+      await user.click(screen.getByRole('button', {name: 'reset non-dirty'}));
+      expect(screen.getByText('Form errors: Required')).toBeTruthy();
+
+      // Update object 1 -> object 0 dirty bit should still be retained.
+      await user.type(screen.getByTestId('input-b'), '3');
+
+      expect(screen.getByText('Field a errors: Required')).toBeTruthy();
+      expect(screen.getByText('Form errors: Required')).toBeTruthy();
+    });
   });
 
   describe('validate', () => {

--- a/src/__tests__/use-form.test.tsx
+++ b/src/__tests__/use-form.test.tsx
@@ -63,3 +63,36 @@ describe('useForm', () => {
     });
   });
 });
+
+describe('handleSubmit', () => {
+  it('submits the latest value when setValue and submit happen in the same tick', async () => {
+    let submittedValue: {name: string} | undefined;
+
+    const Form = () => {
+      const {handleSubmit, setValue, value} = useForm({
+        initialValue: {name: ''},
+      });
+
+      return (
+        <div>
+          <button
+            onClick={() => {
+              setValue({name: 'Ada'});
+              void handleSubmit(data => {
+                submittedValue = data;
+              })();
+            }}
+            title="set and submit"
+          />
+          <p>Form: {JSON.stringify(value)}</p>
+        </div>
+      );
+    };
+
+    render(<Form />);
+
+    await user.click(screen.getByRole('button', {name: 'set and submit'}));
+
+    expect(submittedValue).toEqual({name: 'Ada'});
+  });
+});

--- a/src/__tests__/use-form.test.tsx
+++ b/src/__tests__/use-form.test.tsx
@@ -29,4 +29,37 @@ describe('useForm', () => {
       expect(screen.getByText('Form: "reset"')).toBeTruthy();
     });
   });
+
+  describe('setValue', () => {
+    it('keeps earlier sibling writes from consecutive functional updates', async () => {
+      const Form = () => {
+        const {setValue, value} = useForm({
+          initialValue: {firstName: '', lastName: ''},
+        });
+
+        return (
+          <div>
+            <button
+              onClick={() => {
+                setValue(prev => ({...prev, firstName: 'Ada'}));
+                setValue(prev => ({...prev, lastName: 'Lovelace'}));
+              }}
+              title="set sibling values"
+            />
+            <p>Form: {JSON.stringify(value)}</p>
+          </div>
+        );
+      };
+
+      render(<Form />);
+
+      await user.click(
+        screen.getByRole('button', {name: 'set sibling values'}),
+      );
+
+      expect(
+        screen.getByText('Form: {"firstName":"Ada","lastName":"Lovelace"}'),
+      ).toBeTruthy();
+    });
+  });
 });

--- a/src/use-field-array.ts
+++ b/src/use-field-array.ts
@@ -344,6 +344,12 @@ export const useFieldArray = <T>({
   const [fieldErrors, setFieldErrors] = React.useState<ErrorArray>(() =>
     ErrorArray.fromLength(initialValue.length),
   );
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const dirtyBitsRef = React.useRef(dirtyBits);
+  dirtyBitsRef.current = dirtyBits;
+  const fieldErrorsRef = React.useRef(fieldErrors);
+  fieldErrorsRef.current = fieldErrors;
 
   // Refs to the child fields.
   const childRefs = React.useRef<Array<FieldRef<T> | null>>(
@@ -408,20 +414,29 @@ export const useFieldArray = <T>({
   ) => void;
   const onChangeItem: OnChangeItem = useEventCallback(
     (newItemValue, {isDirty, errors: newItemErrors}, index) => {
+      const currentValue = valueRef.current;
+      const currentDirtyBits = dirtyBitsRef.current;
+      const currentFieldErrors = fieldErrorsRef.current;
+
       // Optimization: don't do anything if nothing changed.
-      const errors = fieldErrors.get(index);
+      const errors = currentFieldErrors.get(index);
       if (
-        newItemValue === value[index] &&
-        isDirty === dirtyBits.get(index) &&
+        newItemValue === currentValue[index] &&
+        isDirty === currentDirtyBits.get(index) &&
         (newItemErrors === errors ||
           (newItemErrors.size === 0 && errors.size === 0))
       ) {
         return;
       }
 
-      const newValue = value.map((v, i) => (i === index ? newItemValue : v));
-      const newDirtyBits = dirtyBits.set(index, isDirty);
-      const newFieldErrors = fieldErrors.set(index, newItemErrors);
+      const newValue = currentValue.map((v, i) =>
+        i === index ? newItemValue : v,
+      );
+      const newDirtyBits = currentDirtyBits.set(index, isDirty);
+      const newFieldErrors = currentFieldErrors.set(index, newItemErrors);
+      valueRef.current = newValue;
+      dirtyBitsRef.current = newDirtyBits;
+      fieldErrorsRef.current = newFieldErrors;
       setDirtyBits(newDirtyBits);
       setFieldErrors(newFieldErrors);
       const newErrors = validateAndSetErrors(newValue);
@@ -460,7 +475,8 @@ export const useFieldArray = <T>({
     (newValue?: T[], options?: ResetOptions): T[] => {
       const {keepDirtyValues = false} = options || {};
       let nextValue = newValue ?? initialValue;
-      const isArrayLenDirty = value.length !== initialValue.length;
+      const currentValue = valueRef.current;
+      const isArrayLenDirty = currentValue.length !== initialValue.length;
       const keepValue = keepDirtyValues && isArrayLenDirty;
       if (!keepValue) {
         setErrors(NO_FIELD_ERRORS);
@@ -468,71 +484,90 @@ export const useFieldArray = <T>({
       if (keepValue) {
         // To keep the current length we might need to shorten or extend the
         // new value.
-        if (value.length > nextValue.length) {
+        if (currentValue.length > nextValue.length) {
           // `undefined` here will cause the child to be reset to its internally
           // stored initial value (e.g. the one passed to `append`)
           nextValue = nextValue.concat(
-            new Array(value.length - nextValue.length).fill(undefined),
+            new Array(currentValue.length - nextValue.length).fill(undefined),
           );
-        } else if (value.length < nextValue.length) {
-          nextValue = nextValue.slice(0, value.length);
+        } else if (currentValue.length < nextValue.length) {
+          nextValue = nextValue.slice(0, currentValue.length);
         }
       }
 
-      // TODO(tibbe): what do we do with the dirty bits and errors here? We will
-      // have incoming calls to `onChangeItem` once this function returns and
-      // they will pick up stale values from these. For example, if we get a
-      // call to update item 0 we will also communicate an empty set of errors
-      // for item 1 even if it was dirty and thus kept its errors.
-      setDirtyBits(BooleanArray.fromLength(nextValue.length));
-      setFieldErrors(ErrorArray.fromLength(nextValue.length));
+      const clearedDirtyBits = BooleanArray.fromLength(nextValue.length);
+      const clearedFieldErrors = ErrorArray.fromLength(nextValue.length);
+      dirtyBitsRef.current = clearedDirtyBits;
+      fieldErrorsRef.current = clearedFieldErrors;
+      setDirtyBits(clearedDirtyBits);
+      setFieldErrors(clearedFieldErrors);
       if (nextValue.length < childRefs.current.length) {
         childRefs.current = childRefs.current.slice(0, nextValue.length);
       } else if (nextValue.length > childRefs.current.length) {
         childRefs.current = [
           ...childRefs.current,
-          ...new Array(nextValue.length - value.length).fill(null),
+          ...new Array(nextValue.length - currentValue.length).fill(null),
         ];
       }
 
-      return childRefs.current.map(
+      const updatedValue = childRefs.current.map(
         (childRef, index) =>
           childRef?.reset(newValue && nextValue[index], options) ??
           nextValue[index],
         options,
       );
+      valueRef.current = updatedValue;
+      return updatedValue;
     },
-    [initialValue, value],
+    [initialValue],
   );
 
   const setValueMethod: FieldRefSetValue<T[]> = React.useCallback(
     (newValue: T[], options) => {
+      const currentValue = valueRef.current;
+      const currentDirtyBits = dirtyBitsRef.current;
+      const currentFieldErrors = fieldErrorsRef.current;
+
       // Optimization: don't do anything if nothing changed.
-      if (newValue === value) {
+      if (newValue === currentValue) {
         return;
       }
 
-      if (newValue.length > value.length) {
-        const numToAdd = newValue.length - value.length;
+      let newDirtyBits = currentDirtyBits;
+      let newFieldErrors = currentFieldErrors;
+
+      if (newValue.length > currentValue.length) {
+        const numToAdd = newValue.length - currentValue.length;
         childRefs.current = [
           ...childRefs.current,
           ...new Array(numToAdd).fill(null),
         ];
-        setDirtyBits(dirtyBits.concat(BooleanArray.fromLength(numToAdd)));
-        setFieldErrors(fieldErrors.concat(ErrorArray.fromLength(numToAdd)));
-      } else if (newValue.length < value.length) {
+        newDirtyBits = currentDirtyBits.concat(
+          BooleanArray.fromLength(numToAdd),
+        );
+        newFieldErrors = currentFieldErrors.concat(
+          ErrorArray.fromLength(numToAdd),
+        );
+      } else if (newValue.length < currentValue.length) {
         childRefs.current = childRefs.current.slice(0, newValue.length);
-        setDirtyBits(dirtyBits.slice(0, newValue.length));
-        setFieldErrors(fieldErrors.slice(0, newValue.length));
+        newDirtyBits = currentDirtyBits.slice(0, newValue.length);
+        newFieldErrors = currentFieldErrors.slice(0, newValue.length);
       }
 
+      valueRef.current = newValue;
+      dirtyBitsRef.current = newDirtyBits;
+      fieldErrorsRef.current = newFieldErrors;
+      setDirtyBits(newDirtyBits);
+      setFieldErrors(newFieldErrors);
+
       const newErrors = validateAndSetErrors(newValue);
-      const allErrors = unionSets([newErrors, fieldErrors.allErrors]);
+      const allErrors = unionSets([newErrors, newFieldErrors.allErrors]);
 
       // We can't rely on future calls to `onChangeItem` to propagate the change
       // as if we e.g. remove all rows we won't get any calls.
       onChange(newValue, {
-        isDirty,
+        isDirty:
+          newValue.length !== initialValue.length || newDirtyBits.isAnyTrue,
         errors: allErrors,
       });
 
@@ -543,18 +578,18 @@ export const useFieldArray = <T>({
         childRefs.current[i]?.setValue(newValue[i], options);
       }
     },
-    [dirtyBits, fieldErrors, isDirty, onChange, validateAndSetErrors, value],
+    [initialValue.length, onChange, validateAndSetErrors],
   );
 
   const validateMethod = React.useCallback(() => {
-    const newErrors = validateAndSetErrors(value);
+    const newErrors = validateAndSetErrors(valueRef.current);
     return unionSets([
       newErrors,
       ...childRefs.current.map(
         childRef => childRef?.validate() ?? NO_FIELD_ERRORS,
       ),
     ]);
-  }, [validateAndSetErrors, value]);
+  }, [validateAndSetErrors]);
 
   React.useImperativeHandle(
     ref,
@@ -564,9 +599,15 @@ export const useFieldArray = <T>({
 
   const append = React.useCallback(
     (initialItemValue: T) => {
-      const newValue = [...value, initialItemValue];
-      const newDirtyBits = dirtyBits.push(false);
-      const newFieldErrors = fieldErrors.push(NO_FIELD_ERRORS);
+      const currentValue = valueRef.current;
+      const currentDirtyBits = dirtyBitsRef.current;
+      const currentFieldErrors = fieldErrorsRef.current;
+      const newValue = [...currentValue, initialItemValue];
+      const newDirtyBits = currentDirtyBits.push(false);
+      const newFieldErrors = currentFieldErrors.push(NO_FIELD_ERRORS);
+      valueRef.current = newValue;
+      dirtyBitsRef.current = newDirtyBits;
+      fieldErrorsRef.current = newFieldErrors;
       setDirtyBits(newDirtyBits);
       setFieldErrors(newFieldErrors);
       childRefs.current = [...childRefs.current, null];
@@ -579,25 +620,25 @@ export const useFieldArray = <T>({
         errors: allErrors,
       });
     },
-    [
-      dirtyBits,
-      fieldErrors,
-      initialValue.length,
-      onChange,
-      validateAndSetErrors,
-      value,
-    ],
+    [initialValue.length, onChange, validateAndSetErrors],
   );
 
   const remove = React.useCallback(
     (index: number) => {
+      const currentValue = valueRef.current;
+
       // Optimization: don't do anything if the index is out of bounds.
-      if (index < 0 || index >= value.length) {
+      if (index < 0 || index >= currentValue.length) {
         return;
       }
-      const newValue = value.filter((_, i) => i !== index);
-      const newDirtyBits = dirtyBits.remove(index);
-      const newFieldErrors = fieldErrors.remove(index);
+      const currentDirtyBits = dirtyBitsRef.current;
+      const currentFieldErrors = fieldErrorsRef.current;
+      const newValue = currentValue.filter((_, i) => i !== index);
+      const newDirtyBits = currentDirtyBits.remove(index);
+      const newFieldErrors = currentFieldErrors.remove(index);
+      valueRef.current = newValue;
+      dirtyBitsRef.current = newDirtyBits;
+      fieldErrorsRef.current = newFieldErrors;
       setDirtyBits(newDirtyBits);
       setFieldErrors(newFieldErrors);
       childRefs.current = childRefs.current.filter((_, i) => i !== index);
@@ -610,14 +651,7 @@ export const useFieldArray = <T>({
         errors: allErrors,
       });
     },
-    [
-      dirtyBits,
-      fieldErrors,
-      initialValue.length,
-      onChange,
-      validateAndSetErrors,
-      value,
-    ],
+    [initialValue.length, onChange, validateAndSetErrors],
   );
 
   return React.useMemo(

--- a/src/use-field-object.ts
+++ b/src/use-field-object.ts
@@ -156,6 +156,12 @@ export const useFieldObject = <O extends {[prop: string]: unknown}>({
   const [fieldErrors, setFieldErrors] = React.useState<ErrorMap<string>>(() =>
     ErrorMap.create(),
   );
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const dirtyBitsRef = React.useRef(dirtyBits);
+  dirtyBitsRef.current = dirtyBits;
+  const fieldErrorsRef = React.useRef(fieldErrors);
+  fieldErrorsRef.current = fieldErrors;
 
   // Dirty state:
   const isDirty = React.useMemo(
@@ -189,18 +195,25 @@ export const useFieldObject = <O extends {[prop: string]: unknown}>({
   ) => void;
   const onChangeItem: OnChangeItem = useEventCallback(
     (newItemValue, {isDirty, errors: newErrors}, key) => {
+      const currentValue = valueRef.current;
+      const currentDirtyBits = dirtyBitsRef.current;
+      const currentFieldErrors = fieldErrorsRef.current;
+
       // Optimization: don't do anything if nothing changed.
-      const errors = fieldErrors.get(key);
+      const errors = currentFieldErrors.get(key);
       if (
-        newItemValue === value[key] &&
-        isDirty === dirtyBits.get(key) &&
+        newItemValue === currentValue[key] &&
+        isDirty === currentDirtyBits.get(key) &&
         (newErrors === errors || (newErrors.size === 0 && errors.size === 0))
       ) {
         return;
       }
-      const newValue = {...value, [key]: newItemValue};
-      const newDirtyBits = dirtyBits.set(key, isDirty);
-      const newFieldErrors = fieldErrors.set(key, newErrors);
+      const newValue = {...currentValue, [key]: newItemValue};
+      const newDirtyBits = currentDirtyBits.set(key, isDirty);
+      const newFieldErrors = currentFieldErrors.set(key, newErrors);
+      valueRef.current = newValue;
+      dirtyBitsRef.current = newDirtyBits;
+      fieldErrorsRef.current = newFieldErrors;
       setDirtyBits(newDirtyBits);
       setFieldErrors(newFieldErrors);
       onChange(newValue, {
@@ -237,11 +250,13 @@ export const useFieldObject = <O extends {[prop: string]: unknown}>({
 
   const reset = React.useCallback(
     (newValue?: O, options?: ResetOptions): O => {
-      // TODO(tibbe): what do we do with the dirty bits and errors here? We will
-      // have incoming calls to `onChangeItem` once this function returns and
-      // they will pick up stale values from these.
-      setDirtyBits(BooleanMap.create());
-      setFieldErrors(ErrorMap.create());
+      // Dirty bits are indexed by field name; we narrow `keyof O` to strings.
+      const clearedDirtyBits = BooleanMap.create<keyof O & string>();
+      const clearedFieldErrors = ErrorMap.create<string>();
+      dirtyBitsRef.current = clearedDirtyBits;
+      fieldErrorsRef.current = clearedFieldErrors;
+      setDirtyBits(clearedDirtyBits);
+      setFieldErrors(clearedFieldErrors);
       const nextValue = newValue ?? initialValue;
 
       // Keys might have been added or removed from the object. Keep existing
@@ -263,6 +278,7 @@ export const useFieldObject = <O extends {[prop: string]: unknown}>({
             nextValue[key as keyof O],
         ]),
       );
+      valueRef.current = updatedValue as O;
       return updatedValue as O;
     },
     [initialValue],
@@ -270,16 +286,20 @@ export const useFieldObject = <O extends {[prop: string]: unknown}>({
 
   const setValue: FieldRefSetValue<{[P in keyof O]: O[P]}> = React.useCallback(
     (newValue: O, options) => {
+      const currentValue = valueRef.current;
+
       // Optimization: don't do anything if nothing changed.
-      if (newValue === value) {
+      if (newValue === currentValue) {
         return;
       }
+
+      valueRef.current = newValue;
 
       Object.entries(childRefs.current).forEach(([key, childRef]) => {
         // Optimization: don't do anything if nothing changed.
         const typedKey = key as keyof O;
         const newPropValue = newValue[typedKey];
-        if (newPropValue === value[typedKey]) {
+        if (newPropValue === currentValue[typedKey]) {
           return;
         }
 
@@ -288,7 +308,7 @@ export const useFieldObject = <O extends {[prop: string]: unknown}>({
         childRef?.setValue(newPropValue, options);
       });
     },
-    [value],
+    [],
   );
 
   const validateMethod = React.useCallback(

--- a/src/use-form.ts
+++ b/src/use-form.ts
@@ -136,6 +136,8 @@ export const useForm = <T>({
   mode = 'onChange',
 }: UseFormProps<T>): UseFormReturn<T> => {
   const [value, setValue] = React.useState(initialInitialValue);
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
   const [isDirty, setIsDirty] = React.useState(false);
   const [errors, setErrors] = React.useState(NO_FIELD_ERRORS);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
@@ -148,6 +150,7 @@ export const useForm = <T>({
   type OnChange = (newValue: T, newFieldState: InternalFieldState) => void;
   const onChange: OnChange = React.useCallback(
     (newValue, {isDirty: newIsDirty, errors: newErrors}) => {
+      valueRef.current = newValue;
       setValue(newValue);
       setIsDirty(newIsDirty);
       setErrors(newErrors);
@@ -169,20 +172,22 @@ export const useForm = <T>({
 
   const setValueMethod: UseFormSetValue<T> = React.useCallback(
     (newValueOrFn, options) => {
+      const prevValue = valueRef.current;
       const newValue =
         typeof newValueOrFn === 'function'
-          ? (newValueOrFn as (prevValue: T) => T)(value)
+          ? (newValueOrFn as (prevValue: T) => T)(prevValue)
           : newValueOrFn;
       // Workaround: we might see multiple calls to `setValue` before the child
       // responds with `onChange` in case the leaf `Field` hasn't been created
       // yet. We need to update the value immediately.
+      valueRef.current = newValue;
       setValue(newValue);
       ref.current?.setValue(newValue, options);
     },
-    [value],
+    [],
   );
 
-  const getValues = React.useCallback(() => value, [value]);
+  const getValues = React.useCallback(() => valueRef.current, []);
 
   const handleSubmit: UseFormHandleSubmit<T> = React.useCallback(
     (onValid, onInvalid) => async (e?: React.BaseSyntheticEvent) => {
@@ -217,6 +222,7 @@ export const useForm = <T>({
     const updatedValue =
       ref.current?.reset(newValue, options) ??
       (newValue !== undefined ? newValue : initialValue);
+    valueRef.current = updatedValue;
     setValue(updatedValue);
   });
 

--- a/src/use-form.ts
+++ b/src/use-form.ts
@@ -200,7 +200,7 @@ export const useForm = <T>({
         }
         const allErrors = ref.current?.validate() ?? NO_FIELD_ERRORS;
         if (allErrors.size === 0) {
-          await onValid(value, e);
+          await onValid(valueRef.current, e);
           setIsSubmitSuccessful(true);
         } else if (onInvalid) {
           await onInvalid(allErrors, e);
@@ -210,7 +210,7 @@ export const useForm = <T>({
         setIsSubmitted(true);
       }
     },
-    [value],
+    [],
   );
 
   const reset = useEventCallback((newValue?: T, options?: ResetOptions) => {


### PR DESCRIPTION
Currently, `setValue`, `onChange`, `handleSubmit` and some of the dirty bit handling use react state. When multiple calls happen in the same tick, the state is not updated between the calls, so we end up dropping the result of all calls except the last one (which acts on the initial stale state).

This PR updates react-compositional-forms to use refs to store the in-flight current state, and allow e.g. several `setValue` calls to apply on top of each other correctly.

The commits update different parts of the code, with the same goal: avoid using stale data to compute the current state:

- Fix root state accumulation when `setValue` is called multiple times
- Fix `handleSubmit` when `setValue` is called just before it
- Manage state, dirty bit and errors in `use-field-object.ts` using refs
- Manage state, dirty bit and errors in `use-field-array.ts` using refs

Tested:
Unit tests, with `yarn test`