### PR TITLE
Make validation functions return ReadonlySet<FieldError>

### DIFF
--- a/src/__tests__/use-field.test.tsx
+++ b/src/__tests__/use-field.test.tsx
@@ -3,13 +3,8 @@ import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
-import {
-  FieldError,
-  NO_FIELD_ERRORS,
-  useField,
-  useFieldObject,
-  useForm,
-} from '..';
+import type {FieldErrors} from '../field-errors';
+import {NO_FIELD_ERRORS, useField, useFieldObject, useForm} from '..';
 import type {TestProps} from '../test-helpers/types';
 import {stringifyErrors} from '../test-helpers/stringify-errors';
 
@@ -191,7 +186,7 @@ describe('Field', () => {
 
     it('reuses state if unchanged', async () => {
       let numCalls = 0;
-      let prevErrors: ReadonlySet<FieldError> | undefined;
+      let prevErrors: FieldErrors | undefined;
       render(
         <FieldTest
           onFormStateChange={formState => {

--- a/src/field-errors.ts
+++ b/src/field-errors.ts
@@ -15,7 +15,7 @@ export type FieldErrors = ReadonlySet<FieldError>;
  *
  * N.B. This set must not be mutated.
  */
-export const NO_FIELD_ERRORS: Set<FieldError> = new Set();
+export const NO_FIELD_ERRORS: FieldErrors = new Set();
 
 // -----------------------------------------------------------------------------
 // fieldErrorSetsDeepEqual

--- a/src/field-errors.ts
+++ b/src/field-errors.ts
@@ -4,6 +4,9 @@ export type FieldError = {
   message?: string;
 };
 
+/** Public error collection type exposed by the library. */
+export type FieldErrors = ReadonlySet<FieldError>;
+
 /**
  * Stable value for an empty set of errors.
  *
@@ -25,8 +28,8 @@ function fieldErrorDeepEqual(errorA: FieldError, errorB: FieldError): boolean {
 }
 
 export function fieldErrorSetsDeepEqual(
-  setA: ReadonlySet<FieldError>,
-  setB: ReadonlySet<FieldError>,
+  setA: FieldErrors,
+  setB: FieldErrors,
 ): boolean {
   if (setA === setB) {
     return true;

--- a/src/form.ts
+++ b/src/form.ts
@@ -10,7 +10,7 @@
  * {@link Form.internal}.
  */
 
-import {FieldError} from './field-errors';
+import type {FieldErrors} from './field-errors';
 import {childPath, keyOf, Path, ROOT, Segment} from './internal/path';
 import {FormDescriptor} from './internal/form-descriptor';
 import {FormStore, ValidateScope, ValidationMode} from './internal/store';
@@ -26,10 +26,10 @@ export interface Form<T> {
   readonly isDirty: boolean;
 
   /** The errors at and below this form. */
-  readonly errors: ReadonlySet<FieldError>;
+  readonly errors: FieldErrors;
 
   /** This form's own errors, excluding its descendants'. */
-  readonly ownErrors: ReadonlySet<FieldError>;
+  readonly ownErrors: FieldErrors;
 
   /** When this form's validators run. */
   readonly validationMode: ValidationMode;
@@ -59,7 +59,7 @@ export interface Form<T> {
   resetToInitial(keepDirtyValues: boolean): T;
 
   /** Validate this form's subtree now; returns the aggregate errors. */
-  validate(): ReadonlySet<FieldError>;
+  validate(): FieldErrors;
 
   /**
    * Only needed when extending the library with new form types: the surface a

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,11 @@
 //   to avoid unnecessary recomputation on every render.
 
 export {type Form as Control} from './form';
-export {type FieldError, NO_FIELD_ERRORS} from './field-errors';
+export {
+  type FieldError,
+  type FieldErrors,
+  NO_FIELD_ERRORS,
+} from './field-errors';
 export {type ValidationMode} from './internal/store';
 export {
   type UseFieldField as FieldControl,

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -9,6 +9,7 @@
  * unchanged validation result propagates no new reference to subscribers.
  */
 
+import type {FieldErrors} from '../field-errors';
 import {
   FieldError,
   fieldErrorSetsDeepEqual,
@@ -26,10 +27,10 @@ import {isDescendantOrSelf, Path, pathOf, PathKey} from './path';
  *   array-level error before an element's). {@link NO_FIELD_ERRORS} when empty.
  */
 export function aggregateErrors(
-  ownErrors: ReadonlyMap<PathKey, ReadonlySet<FieldError>>,
+  ownErrors: ReadonlyMap<PathKey, FieldErrors>,
   path: Path,
-): ReadonlySet<FieldError> {
-  const matches: {depth: number; errs: ReadonlySet<FieldError>}[] = [];
+): FieldErrors {
+  const matches: {depth: number; errs: FieldErrors}[] = [];
   for (const [key, errs] of ownErrors) {
     const kp = pathOf(key);
     if (isDescendantOrSelf(kp, path)) matches.push({depth: kp.length, errs});
@@ -52,10 +53,10 @@ export function aggregateErrors(
  * @returns The updated map, or `map` unchanged when nothing differs.
  */
 export function withEntry(
-  map: ReadonlyMap<PathKey, ReadonlySet<FieldError>>,
+  map: ReadonlyMap<PathKey, FieldErrors>,
   key: PathKey,
-  errs: ReadonlySet<FieldError>,
-): ReadonlyMap<PathKey, ReadonlySet<FieldError>> {
+  errs: FieldErrors,
+): ReadonlyMap<PathKey, FieldErrors> {
   const prev = map.get(key);
   if (prev === errs || (prev === undefined && errs.size === 0)) return map;
   if (prev !== undefined && fieldErrorSetsDeepEqual(prev, errs)) return map;
@@ -77,10 +78,10 @@ export function withEntry(
  * @returns The updated map, or `map` unchanged when nothing was dropped.
  */
 export function keepDirtyErrors(
-  map: ReadonlyMap<PathKey, ReadonlySet<FieldError>>,
+  map: ReadonlyMap<PathKey, FieldErrors>,
   path: Path,
   dirtyPrefixes: ReadonlySet<PathKey>,
-): ReadonlyMap<PathKey, ReadonlySet<FieldError>> {
+): ReadonlyMap<PathKey, FieldErrors> {
   let changed = false;
   const next = new Map(map);
   for (const key of map.keys()) {

--- a/src/internal/form-descriptor.ts
+++ b/src/internal/form-descriptor.ts
@@ -23,11 +23,11 @@
  * See {@link FormDescriptor} for a worked example.
  */
 
-import {FieldError} from '../field-errors';
+import type {FieldErrors} from '../field-errors';
 import {Segment} from './path';
 
 /** Validate a value, returning its errors (empty when valid). */
-export type Validator<T> = (value: T) => Set<FieldError>;
+export type Validator<T> = (value: T) => FieldErrors;
 
 /** Decide whether two values of a form are equal, for its dirtiness check. */
 export type Equals<T> = (a: T, b: T) => boolean;

--- a/src/internal/store.ts
+++ b/src/internal/store.ts
@@ -13,6 +13,7 @@
  * register with it; its dirty and reset walks consult that registry.
  */
 
+import type {FieldErrors} from '../field-errors';
 import {FieldError, NO_FIELD_ERRORS} from '../field-errors';
 import {aggregateErrors, keepDirtyErrors, withEntry} from './errors';
 import {
@@ -66,7 +67,7 @@ export type Snapshot = {
   readonly initialValue: unknown;
 
   /** Each form's own (non-aggregated) validation errors, keyed by path. */
-  readonly ownErrors: ReadonlyMap<PathKey, ReadonlySet<FieldError>>;
+  readonly ownErrors: ReadonlyMap<PathKey, FieldErrors>;
 
   /**
    * Baselines for elements (leaf or composite) grown past the initial structure,
@@ -230,10 +231,10 @@ export class FormStore {
   // a child's value reaching its parent re-checks each rule that spans it (an
   // array's length rule, an object's cross-field rule).
   private validateUp(
-    ownErrors: ReadonlyMap<PathKey, ReadonlySet<FieldError>>,
+    ownErrors: ReadonlyMap<PathKey, FieldErrors>,
     path: Path,
     rootValue: unknown,
-  ): ReadonlyMap<PathKey, ReadonlySet<FieldError>> {
+  ): ReadonlyMap<PathKey, FieldErrors> {
     for (const pk of prefixesOf(path)) {
       const form = this.forms.get(keyOf(pk));
       if (form?.descriptor.validate) {
@@ -276,10 +277,10 @@ export class FormStore {
   // child it replaced. A descendant whose value is gone has its stale error
   // cleared instead.
   private validateSubtreeAndUp(
-    ownErrors: ReadonlyMap<PathKey, ReadonlySet<FieldError>>,
+    ownErrors: ReadonlyMap<PathKey, FieldErrors>,
     path: Path,
     rootValue: unknown,
-  ): ReadonlyMap<PathKey, ReadonlySet<FieldError>> {
+  ): ReadonlyMap<PathKey, FieldErrors> {
     for (const [key, form] of this.forms) {
       if (!form.descriptor.validate) continue;
       const np = pathOf(key);
@@ -427,7 +428,7 @@ export class FormStore {
    * the results. Returns the union of the errors found, or
    * {@link NO_FIELD_ERRORS} when the subtree is valid.
    */
-  validateSubtree(path: Path): ReadonlySet<FieldError> {
+  validateSubtree(path: Path): FieldErrors {
     let ownErrors = this.snapshot.ownErrors;
     const all = new Set<FieldError>();
     for (const [key, form] of this.forms) {
@@ -452,12 +453,12 @@ export class FormStore {
   // --- reads ----------------------------------------------------------------
 
   /** Union of own errors at and below `path`. */
-  aggregateErrorsAt(path: Path): ReadonlySet<FieldError> {
+  aggregateErrorsAt(path: Path): FieldErrors {
     return aggregateErrors(this.snapshot.ownErrors, path);
   }
 
   /** This form's own errors only (excludes descendants). */
-  ownErrorsAt(path: Path): ReadonlySet<FieldError> {
+  ownErrorsAt(path: Path): FieldErrors {
     return this.snapshot.ownErrors.get(keyOf(path)) ?? NO_FIELD_ERRORS;
   }
 }

--- a/src/internal/use-store-slice.ts
+++ b/src/internal/use-store-slice.ts
@@ -9,7 +9,8 @@
 
 import React from 'react';
 
-import {FieldError, fieldErrorSetsDeepEqual} from '../field-errors';
+import type {FieldErrors} from '../field-errors';
+import {fieldErrorSetsDeepEqual} from '../field-errors';
 import {Form} from '../form';
 import {FormDescriptor} from './form-descriptor';
 import {Snapshot} from './store';
@@ -54,10 +55,7 @@ export function useFormSlice<T, S>(
 }
 
 /** Deep-equal comparison for error sets, for use as a slice `isEqual`. */
-export function errorSetsEqual(
-  a: ReadonlySet<FieldError>,
-  b: ReadonlySet<FieldError>,
-): boolean {
+export function errorSetsEqual(a: FieldErrors, b: FieldErrors): boolean {
   return fieldErrorSetsDeepEqual(a, b);
 }
 

--- a/src/test-helpers/TextField.tsx
+++ b/src/test-helpers/TextField.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import {Control, FieldError, useField} from '..';
+import {Control, type FieldErrors, useField} from '..';
 import {stringifyErrors} from './stringify-errors';
 
 export type TextFieldProps = {
   name: string;
   parentControl: Control<string>;
-  validate?: (value: string) => Set<FieldError>;
+  validate?: (value: string) => FieldErrors;
 };
 
 const TextField = ({name, parentControl, validate}: TextFieldProps) => {

--- a/src/test-helpers/stringify-errors.ts
+++ b/src/test-helpers/stringify-errors.ts
@@ -1,5 +1,5 @@
-import {FieldError} from '..';
+import type {FieldErrors} from '..';
 
-export function stringifyErrors(errors: ReadonlySet<FieldError>): string {
+export function stringifyErrors(errors: FieldErrors): string {
   return [...errors].map(e => e.message).join(', ');
 }

--- a/src/test-helpers/types.ts
+++ b/src/test-helpers/types.ts
@@ -1,4 +1,4 @@
-import {FieldError, FormState} from '..';
+import {type FieldErrors, FormState} from '..';
 
 /** Allows for configuring the test behavior (e.g. buttons). */
 export type TestProps<T> = {
@@ -27,7 +27,7 @@ export type TestProps<T> = {
 
   setValueMode?: 'onBlur' | 'onChange' | 'set';
 
-  validate?: (value: T) => Set<FieldError>;
+  validate?: (value: T) => FieldErrors;
 
   mode?: 'onBlur' | 'onChange';
 };

--- a/src/use-field-array.ts
+++ b/src/use-field-array.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {FieldError} from './field-errors';
+import type {FieldErrors} from './field-errors';
 import {Form} from './form';
 import {FormDescriptor, Validator} from './internal/form-descriptor';
 import {
@@ -25,7 +25,7 @@ export type UseFieldArrayProps<T> = {
    * @returns A set of errors. If the set is empty the value is considered
    * valid.
    */
-  validate?: (value: T[]) => Set<FieldError>;
+  validate?: (value: T[]) => FieldErrors;
 };
 
 export type UseFieldArrayField<T> = {
@@ -50,7 +50,7 @@ export type UseFieldArrayReturn<T> = {
    *
    * If empty the field is valid.
    */
-  errors: ReadonlySet<FieldError>;
+  errors: FieldErrors;
 
   /**
    * The current children.

--- a/src/use-field.ts
+++ b/src/use-field.ts
@@ -1,4 +1,4 @@
-import {FieldError} from './field-errors';
+import type {FieldErrors} from './field-errors';
 import {Form} from './form';
 import {Equals, FormDescriptor, Validator} from './internal/form-descriptor';
 import {
@@ -40,7 +40,7 @@ export type UseFieldFieldState = {
    *
    * If empty the field is valid.
    */
-  errors: ReadonlySet<FieldError>;
+  errors: FieldErrors;
 
   /**
    * Is the field dirty?
@@ -81,7 +81,7 @@ export type UseFieldProps<T> = {
    * @returns A set of errors. If the set is empty the value is considered
    * valid.
    */
-  validate?: (value: T) => Set<FieldError>;
+  validate?: (value: T) => FieldErrors;
 };
 
 /**

--- a/src/use-field.ts
+++ b/src/use-field.ts
@@ -78,8 +78,8 @@ export type UseFieldProps<T> = {
    * Validation function that validates the field value.
    *
    * @param value The value to validate.
-   * @returns A set of errors. If the set is empty the value is considered
-   * valid.
+   * @returns A readonly-set of errors. If the set is empty the value is
+   * considered valid.
    */
   validate?: (value: T) => FieldErrors;
 };

--- a/src/use-form.ts
+++ b/src/use-form.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {FieldError} from './field-errors';
+import type {FieldErrors} from './field-errors';
 import {Form, createRootForm} from './form';
 import {ValidationMode} from './internal/store';
 import {errorSetsEqual, useFormSlice} from './internal/use-store-slice';
@@ -40,7 +40,7 @@ export type FormState = {
    *
    * Empty if the form is valid.
    */
-  errors: ReadonlySet<FieldError>;
+  errors: FieldErrors;
 
   /** True if any field is dirty, otherwise false. */
   isDirty: boolean;
@@ -77,7 +77,7 @@ export type SubmitHandler<T> = (
 
 export type SubmitErrorHandler = (
   /** Non-empty set of validation errors. */
-  errors: ReadonlySet<FieldError>,
+  errors: FieldErrors,
   event?: React.BaseSyntheticEvent,
 ) => void | Promise<void>;
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -3,6 +3,7 @@
  */
 
 import {FieldError, NO_FIELD_ERRORS} from './field-errors';
+import type {FieldErrors} from './field-errors';
 
 type ValueMessage<T> = {
   value: T;
@@ -24,7 +25,7 @@ type ArrayRules = {
 };
 
 export const arrayRules = <T>({required}: ArrayRules) => {
-  const validate = (value: T[]) => {
+  const validate = (value: T[]): FieldErrors => {
     const errors = new Set<FieldError>();
 
     // required
@@ -65,7 +66,7 @@ export const stringRules = ({
   pattern,
   required,
 }: StringRules) => {
-  const validate = (value: string) => {
+  const validate = (value: string): FieldErrors => {
     // Any maxLength value must be greater than or equal to the value of
     // minLength, if present.
     if (maxLength && minLength) {
@@ -152,8 +153,6 @@ export const stringRules = ({
  * @param errors The set of errors.
  * @returns An arbitrary error from the set of errors, if any.
  */
-export function someError(
-  errors: ReadonlySet<FieldError>,
-): FieldError | undefined {
+export function someError(errors: FieldErrors): FieldError | undefined {
   return errors.values().next().value;
 }


### PR DESCRIPTION
Two commits:
- define new FieldErrors type as ReadonlySet<FieldError> and use it consistently throughout the repo
- change all remaining validation functions to return FieldErrors (readonly-set), rather than Set<FieldError)

Tested:
yarn test
Checked integration with benetics package: unit test and lint pass.