### PR TITLE
Accept ReadonlySet in someError

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -152,6 +152,8 @@ export const stringRules = ({
  * @param errors The set of errors.
  * @returns An arbitrary error from the set of errors, if any.
  */
-export function someError(errors: Set<FieldError>): FieldError | undefined {
+export function someError(
+  errors: ReadonlySet<FieldError>,
+): FieldError | undefined {
   return errors.values().next().value;
 }


### PR DESCRIPTION
A regression from the per-root store refactor.

Every producer of field errors — `Form.errors`, `Form.ownErrors`, and the `fieldState.errors` returned by the hooks — now exposes `ReadonlySet<FieldError>`, but `someError` still required a mutable `Set`, so callers passing those errors failed to type-check. `someError` only reads the set, so its parameter is widened to `ReadonlySet<FieldError>`.

## Tested on

- `yarn tsc:no-emit`, `yarn lint`, `yarn test` (109 tests) all pass.