### PR TITLE
Recut the extension API as Leaf | Composite over a keyed container

### DIFF
--- a/src/__tests__/use-field-array.test.tsx
+++ b/src/__tests__/use-field-array.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import {
   Control,
   NO_FIELD_ERRORS,
+  useField,
   useFieldArray,
   useFieldObject,
   useForm,
@@ -798,5 +799,130 @@ describe('FieldArray', () => {
     // The appended row — itself an array — is clean until edited, even though the
     // outer array is dirty because its length grew.
     expect(screen.getByText('row1: clean')).toBeTruthy();
+  });
+
+  describe('keepDirtyValues reset never hands a leaf equality an off-type value', () => {
+    type Row = {name: string};
+
+    // A leaf equality that parses its inputs, so it throws on anything but its
+    // declared type. The core must never call it with a value from outside that
+    // type — an absent baseline read as `undefined`.
+    const strictStringEquals = (a: string, b: string) => {
+      if (typeof a !== 'string' || typeof b !== 'string') {
+        throw new Error(
+          `equality received a non-string: ${JSON.stringify(a)}, ${JSON.stringify(b)}`,
+        );
+      }
+      return a === b;
+    };
+
+    const Cell = ({
+      control,
+      name,
+    }: {
+      control: Control<string>;
+      name: string;
+    }) => {
+      const {
+        field: {onChange, value},
+      } = useField({control, equalsFn: strictStringEquals});
+      return (
+        <input
+          data-testid={`cell-${name}`}
+          onChange={e => onChange(e.target.value)}
+          value={value}
+        />
+      );
+    };
+
+    const RowFields = ({
+      control,
+      name,
+    }: {
+      control: Control<Row>;
+      name: string;
+    }) => {
+      const {fields} = useFieldObject({control});
+      return <Cell control={fields.name.control} name={name} />;
+    };
+
+    const Table = ({
+      initialValue,
+      resetValue,
+    }: {
+      initialValue: Row[];
+      resetValue: Row[];
+    }) => {
+      const {control, reset} = useForm<Row[]>({initialValue});
+      const {fields, append} = useFieldArray({control});
+      return (
+        <div>
+          {fields.map((field, i) => (
+            <RowFields key={i} control={field.control} name={i.toString()} />
+          ))}
+          <button onClick={() => append({name: 'appended'})} title="add row" />
+          <button
+            onClick={() => reset(resetValue, {keepDirtyValues: true})}
+            title="reset"
+          />
+        </div>
+      );
+    };
+
+    it('keeps a grown row and resets the rest without throwing', async () => {
+      // The appended row has no counterpart in the initial value, so its cell has
+      // no initial baseline. Resetting onto a value that also holds that row used
+      // to parse `undefined` as the cell's baseline and throw.
+      render(
+        <Table
+          initialValue={[{name: 'a'}]}
+          resetValue={[{name: 'x'}, {name: 'y'}]}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', {name: 'add row'}));
+      await user.click(screen.getByRole('button', {name: 'reset'}));
+
+      expect(screen.getByTestId('cell-0')).toHaveValue('x');
+      expect(screen.getByTestId('cell-1')).toHaveValue('y');
+    });
+
+    it('merges a grown-then-edited row against its own frozen baseline', async () => {
+      // Editing the appended row forces the row's object rebuild to run: its cell
+      // is compared against the frozen row's cell (a real string), not an absent
+      // initial. The edited grown row is dirty, so keepDirtyValues keeps it.
+      render(
+        <Table
+          initialValue={[{name: 'a'}]}
+          resetValue={[{name: 'x'}, {name: 'y'}]}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', {name: 'add row'}));
+      await user.type(screen.getByTestId('cell-1'), '!');
+      await user.click(screen.getByRole('button', {name: 'reset'}));
+
+      expect(screen.getByTestId('cell-0')).toHaveValue('x');
+      expect(screen.getByTestId('cell-1')).toHaveValue('appended!');
+    });
+
+    it('takes reset-only rows from the reset when the reset grows the array', async () => {
+      // The reset is longer than the current value, so its extra row exists only
+      // in the reset: the array rebuild takes it directly rather than recursing
+      // into a current row that isn't there. Row 0 is edited (kept dirty) so the
+      // merge runs rather than the whole-subtree reset short-circuit.
+      render(
+        <Table
+          initialValue={[{name: 'a'}]}
+          resetValue={[{name: 'x'}, {name: 'y'}]}
+        />,
+      );
+
+      await user.type(screen.getByTestId('cell-0'), '!');
+      await user.click(screen.getByRole('button', {name: 'reset'}));
+
+      expect(screen.getByTestId('cell-0')).toHaveValue('a!');
+      expect(screen.getByTestId('cell-1')).toHaveValue('y');
+    });
   });
 });

--- a/src/form.ts
+++ b/src/form.ts
@@ -81,16 +81,12 @@ export interface FormInternal<T> {
   readonly path: Path;
 
   /**
-   * Build the `Form` for the child at `segment`. A combinator calls this to hand
+   * Build the `Form` for the child at `key`. A combinator calls this to hand
    * each of its children a `Form` of its own: `read` extracts the child's value
    * from this form's value, and `write` produces a new value of this form with
-   * one child's value replaced. The child lives one segment deeper in the tree.
+   * one child's value replaced. The child lives one level deeper in the tree.
    */
-  child<S>(
-    segment: Segment,
-    read: (t: T) => S,
-    write: (t: T, s: S) => T,
-  ): Form<S>;
+  child<S>(key: Segment, read: (t: T) => S, write: (t: T, s: S) => T): Form<S>;
 
   /**
    * Declare how this form behaves — its validator, value equality, and how it
@@ -99,8 +95,8 @@ export interface FormInternal<T> {
    */
   register(descriptor: FormDescriptor<T>): void;
 
-  /** Reindex this form's children by mapping each segment to its new segment (or `null` to drop). */
-  remapChildren(remap: (childSegment: Segment) => Segment | null): void;
+  /** Reindex this form's children by mapping each key to its new key (or `null` to drop). */
+  remapChildren(remap: (key: Segment) => Segment | null): void;
 }
 
 export function makeForm<T>(
@@ -168,10 +164,10 @@ export function makeForm<T>(
     internal: {
       store,
       path,
-      child(segment, childRead, childWrite) {
+      child(key, childRead, childWrite) {
         return makeForm(
           store,
-          childPath(path, segment),
+          childPath(path, key),
           root => childRead(read(root)),
           (root, s) => write(root, childWrite(read(root), s)),
         );

--- a/src/internal/form-descriptor.ts
+++ b/src/internal/form-descriptor.ts
@@ -3,120 +3,119 @@
  *
  * A *form* is a value being edited at one position in a form tree: the whole
  * record at the root, an object partway down, an array, a single text field at a
- * leaf. To support a kind of value — an object, an array, a `Set`, a date, a
- * domain object — write a {@link FormDescriptor} for it and register it on the
- * form with `form.internal.register(descriptor)`.
+ * leaf. To support a kind of value — a `Set`, a `Map`, a date, a domain object —
+ * write a {@link FormDescriptor} for it and register it on the form with
+ * `form.internal.register(descriptor)`.
  *
- * A descriptor answers, for one form:
+ * A form is either a {@link Leaf} or a {@link Composite}:
  *
- *   - Whether the form decomposes into child forms, and into which.
- *     ({@link FormDescriptor.decompose}.) A form with children is a *composite*; a
- *     form with none is a *leaf*. Editing, validation, and reset reach a child
- *     through its parent's decomposition.
- *   - Whether the form's own value is unchanged, apart from its children — value
- *     equality for a leaf, structural identity for a collection (an array's
- *     length, a map's keys). ({@link FormDescriptor.equals}.)
- *   - How to rebuild the value when only part of it is reset.
- *     ({@link FormDescriptor.rebuild}.)
- *   - Whether the value is valid. ({@link FormDescriptor.validate}.)
+ *   - A **Leaf** is edited as one opaque value. It says only how two of its
+ *     values compare ({@link Leaf.equals}) and, optionally, whether a value is
+ *     valid ({@link Leaf.validate}).
+ *   - A **Composite** is a container of child forms, each under a JSON key. It
+ *     says how a value takes apart into `(key, child)` pairs ({@link
+ *     Composite.decompose}) and how such pairs assemble back into a value
+ *     ({@link Composite.build}). Its dirtiness, validity, and reset all derive
+ *     from its children plus that key structure; it needs no own equality,
+ *     because a composite is dirty exactly when a child is or its key set has
+ *     changed.
  *
- * See {@link FormDescriptor} for a worked example.
+ * A composite decomposes into and builds from `(key, child)` pairs, so any
+ * container fits: an array uses its indices as keys, an object its property
+ * names, a `Map` its keys. `decompose` and `build` must round-trip — building
+ * from what `decompose` produced returns an equal value.
  */
 
 import type {FieldErrors} from '../field-errors';
-import {Segment} from './path';
+import {Json} from './path';
 
 /** Validate a value, returning its errors (empty when valid). */
 export type Validator<T> = (value: T) => FieldErrors;
 
-/** Decide whether two values of a form are equal, for its dirtiness check. */
+/** Decide whether two leaf values are equal, for its dirtiness check. */
 export type Equals<T> = (a: T, b: T) => boolean;
 
 /**
- * One child a composite form decomposes into: its `segment`, the child's identity
- * under its parent, and `read`, which extracts the child's value from the
- * parent's value.
- *
- * `T` is the parent value's type. It appears only in `read`'s parameter — the
- * child's value type is erased to `unknown` — so that `decompose: (value: T) =>
- * ChildRef<T>[]` types each `read` to receive the value it decomposed.
+ * One child a composite decomposes into: its `key` and its `read`. The `key` is
+ * the child's identity under its parent — any JSON value. `read` projects the
+ * child's value out of a parent value; it is written against the key, not a
+ * captured value, so the same {@link ChildRef} reads its child out of any parent
+ * value of that shape, not only the one it was decomposed from.
  */
-export type ChildRef<T = unknown> = {
-  readonly segment: Segment;
-  readonly read: (parentValue: T) => unknown;
+export type ChildRef<T, Key extends Json, Child> = {
+  readonly key: Key;
+  readonly read: (parentValue: T) => Child;
 };
 
 /**
- * What a combinator tells the library about one kind of form. The fields are
- * independent and all optional: supplying none describes a plain leaf compared
- * with `Object.is`; a leaf overrides `equals`/`validate` as needed; a composite
- * additionally supplies `decompose` and `rebuild`. The library reads `decompose`
- * to tell leaf from composite and does not enforce the pairing, so supplying a
- * coherent set is the combinator's responsibility.
+ * A form edited as one opaque value, with no children.
  *
  * @example
- * // A leaf holding a Date, dirty when the instant changes:
- * const dateForm: FormDescriptor<Date> = {
+ * // A Date leaf, dirty when the instant changes:
+ * const dateForm: Leaf<Date> = {
  *   equals: (a, b) => a.getTime() === b.getTime(),
  * };
- *
- * @example
- * // A composite: an object that splits into its keys and rebuilds from them.
- * const objectForm: FormDescriptor<Record<string, unknown>> = {
- *   decompose: obj =>
- *     Object.keys(obj).map(k => ({segment: k, read: o => o[k]})),
- *   equals: () => true, // no own value beyond its children
- *   rebuild: (current, initial, reset, child) => {
- *     // Take the reset value's key set, falling back to the current keys when
- *     // there is no reset value at this position.
- *     const out: Record<string, unknown> = {};
- *     for (const k of Object.keys(reset ?? current)) {
- *       out[k] = child(k, current[k], initial?.[k], reset?.[k]);
- *     }
- *     return out;
- *   },
- * };
  */
-export interface FormDescriptor<T = unknown> {
+export type Leaf<T> = {
   /**
-   * The form's child forms, extracted from its value. A leaf omits this (or
-   * returns no children); a composite returns one {@link ChildRef} per child.
-   */
-  readonly decompose?: (value: T) => readonly ChildRef<T>[];
-
-  /**
-   * This form's own equality, ignoring its children: whether two of its values
-   * are the same apart from anything the children own. Defaults to `Object.is`.
-   *
-   * A leaf overrides it for a value compared by more than reference — a `Set`, a
-   * `Date`, a domain object. A composite must override it too: an object
-   * carrying no own value beyond its children uses `() => true`; a collection
-   * uses its structural identity — an array its length, a map its key set. (A
-   * composite's value object is rebuilt on each edit, so the default `Object.is`
-   * would never hold.)
+   * Whether two of this leaf's values are equal, for its dirtiness check.
+   * Defaults to `Object.is`. Override for a value compared by more than
+   * reference — a `Date`, a `Set` held opaque, a domain object.
    */
   readonly equals?: Equals<T>;
 
-  /**
-   * Rebuild the form's value for a partial (`keepDirtyValues`) reset, in which a
-   * changed child keeps its current value and an unchanged child takes the reset
-   * value. Reconstruct the value from the children, deciding each one with
-   * `child(segment, childCurrent, childInitial, childReset)` — which applies the
-   * same keep-or-reset rule one level down and returns that child's value.
-   * `initialValue` and `resetValue` are `undefined` when the form has none.
-   */
-  readonly rebuild?: (
-    value: T,
-    initialValue: T | undefined,
-    resetValue: T | undefined,
-    child: (
-      segment: Segment,
-      childCurrent: unknown,
-      childInitial: unknown,
-      childReset: unknown,
-    ) => unknown,
-  ) => T;
-
-  /** Validate the form's value, returning its errors (empty when valid). */
+  /** Validate the value, returning its errors (empty when valid). */
   readonly validate?: Validator<T>;
+};
+
+/**
+ * A form whose value is a container of child forms, each under a JSON key.
+ *
+ * `decompose` takes a value apart into its `(key, read)` children; `build`
+ * assembles a value from `(key, child)` pairs. The two must round-trip.
+ * Dirtiness and reset derive from these plus the key structure — a composite is
+ * dirty when a child is or its key set differs from its initial — so it supplies
+ * no `equals` of its own.
+ *
+ * `Key` and `Child` are the container's key and element types — `number`/`T` for
+ * an array of `T`, `K`/`V` for a `Map<K, V>`. A heterogeneous container (an
+ * object whose properties differ in type) uses `Child = unknown`.
+ *
+ * @example
+ * // An object that splits into its keys and rebuilds from them:
+ * const objectForm: Composite<Record<string, unknown>, string, unknown> = {
+ *   decompose: obj =>
+ *     Object.keys(obj).map(k => ({key: k, read: o => o[k]})),
+ *   build: entries => Object.fromEntries(entries),
+ * };
+ */
+export type Composite<T, Key extends Json, Child> = {
+  /** Take a value apart into its children, each a `(key, read)` pair. */
+  readonly decompose: (value: T) => Iterable<ChildRef<T, Key, Child>>;
+
+  /**
+   * Assemble a value from `(key, child)` pairs. The pairs' key set may differ
+   * from any current value's — a reset can add or drop an element — so `build`
+   * reconstructs from the pairs it is given rather than editing a value in place.
+   */
+  readonly build: (children: Iterable<readonly [Key, Child]>) => T;
+
+  /** Validate the value, returning its errors (empty when valid). */
+  readonly validate?: Validator<T>;
+};
+
+/**
+ * What a combinator tells the library about one kind of form: a {@link Leaf} or a
+ * {@link Composite}. `FormDescriptor` erases the container's key and element types
+ * to `Json`/`unknown` — one type spans forms of every shape — while a combinator
+ * writes a `Leaf` or `Composite` at its precise `Key`/`Child` types and registers
+ * that.
+ */
+export type FormDescriptor<T = unknown> = Leaf<T> | Composite<T, Json, unknown>;
+
+/** Whether a descriptor describes a {@link Composite} (has children). */
+export function isComposite<T>(
+  descriptor: FormDescriptor<T>,
+): descriptor is Composite<T, Json, unknown> {
+  return 'decompose' in descriptor;
 }

--- a/src/internal/store.ts
+++ b/src/internal/store.ts
@@ -31,7 +31,7 @@ import {
   Segment,
   segmentsEqual,
 } from './path';
-import {ChildRef, FormDescriptor} from './form-descriptor';
+import {FormDescriptor, isComposite} from './form-descriptor';
 import {DescriptorAt, rebuildKeepDirty, walkValue} from './traversal';
 
 /** When a form's validators run: on every change, or only on blur. */
@@ -188,25 +188,15 @@ export class FormStore {
   /**
    * Record how the form at `path` behaves, so the walks and validation can find
    * it. `read` extracts the form's value from a root value; `descriptor`
-   * declares its structure and rules. Re-registering merges the supplied
-   * descriptor fields over the existing ones, leaving fields the new descriptor
-   * omits in place.
+   * declares its structure and rules. Re-registering replaces the previous
+   * descriptor, so a validator closing over fresh props takes effect.
    */
   register(
     path: Path,
     read: (root: unknown) => unknown,
     descriptor: FormDescriptor,
   ): void {
-    const k = keyOf(path);
-    const prev = this.forms.get(k)?.descriptor;
-    // A literal, not a keyed loop, so each field stays typed.
-    const merged: FormDescriptor = {
-      decompose: descriptor.decompose ?? prev?.decompose,
-      equals: descriptor.equals ?? prev?.equals,
-      rebuild: descriptor.rebuild ?? prev?.rebuild,
-      validate: descriptor.validate ?? prev?.validate,
-    };
-    this.forms.set(k, {read, descriptor: merged});
+    this.forms.set(keyOf(path), {read, descriptor});
   }
 
   /**
@@ -257,16 +247,18 @@ export class FormStore {
     let prefix: Path = ROOT;
     for (const seg of path) {
       const desc = this.descriptorAt(prefix);
-      if (!desc?.decompose) return false;
-      let found: ChildRef | undefined;
+      if (desc === undefined || !isComposite(desc)) return false;
+      let next: unknown;
+      let matched = false;
       for (const ref of desc.decompose(cur)) {
-        if (segmentsEqual(ref.segment, seg)) {
-          found = ref;
+        if (segmentsEqual(ref.key, seg)) {
+          next = ref.read(cur);
+          matched = true;
           break;
         }
       }
-      if (!found) return false;
-      cur = found.read(cur);
+      if (!matched) return false;
+      cur = next;
       prefix = childPath(prefix, seg);
     }
     return true;

--- a/src/internal/traversal.ts
+++ b/src/internal/traversal.ts
@@ -1,18 +1,26 @@
 /**
  * The two structural walks over a value tree.
  *
- * Both walks recurse through a form's children using its {@link FormDescriptor}.
- * {@link walkValue} computes which forms are dirty;
- * {@link rebuildKeepDirty} rebuilds a subtree's value for a `keepDirtyValues`
- * reset.
+ * Both walks recurse through a composite's children using its {@link
+ * FormDescriptor}: they decompose each value tree they visit into `(key, child)`
+ * pairs and align those pairs by key. {@link walkValue} computes which forms are
+ * dirty; {@link rebuildKeepDirty} rebuilds a subtree's value for a
+ * `keepDirtyValues` reset.
  *
  * A form's *baseline* is the value its dirtiness is measured against — normally
  * its initial value, but a frozen value for an element grown past the initial
  * structure (see {@link walkValue}).
+ *
+ * Absence — a position one tree holds and another lacks — is decided by key-set
+ * membership, never by a sentinel value. {@link walkValue} freezes a grown
+ * element and measures it against its own frozen value; {@link rebuild} carries a
+ * missing initial or reset value as an absent {@link Slot}. So a leaf's `equals`
+ * and a composite's `build` are only ever handed real values of the form's type,
+ * never an `undefined` standing in for a missing position.
  */
 
-import {FormDescriptor} from './form-descriptor';
-import {childPath, keyOf, Path, PathKey, ROOT} from './path';
+import {Composite, FormDescriptor, isComposite} from './form-descriptor';
+import {childPath, keyOf, Path, PathKey, ROOT, Segment} from './path';
 
 /** The descriptor registered for the form at `path`, if any. */
 export type DescriptorAt = (path: Path) => FormDescriptor | undefined;
@@ -26,28 +34,61 @@ export type WalkResult = {
   readonly frozenInitials: ReadonlyMap<PathKey, unknown>;
 };
 
-/**
- * A form's own equality, ignoring its children: the `equals` its descriptor
- * declares, or `Object.is` when it declares none — including before the form's
- * descriptor has registered.
- */
-function ownEquals(
+/** A position a value tree either fills (`present`) or lacks. */
+type Slot =
+  | {readonly present: true; readonly value: unknown}
+  | {readonly present: false};
+const present = (value: unknown): Slot => ({present: true, value});
+const ABSENT: Slot = {present: false};
+
+/** Whether a leaf's own value is unchanged: its `equals`, or `Object.is`. */
+function leafEquals(
   desc: FormDescriptor | undefined,
 ): (a: unknown, b: unknown) => boolean {
-  return desc?.equals ?? Object.is;
+  return (desc && !isComposite(desc) && desc.equals) || Object.is;
+}
+
+/**
+ * A composite's children keyed by their flattened path key, each carrying its
+ * original segment (for descent and reconstruction) and its value.
+ *
+ * `null`/`undefined` isn't given dirtiness meaning here — that stays structural,
+ * by key set. It's just not a container to take apart, so it yields no children;
+ * a position that goes from `null` to a populated value reads as a grown key set.
+ */
+function childrenByKey(
+  desc: Composite<unknown, Segment, unknown>,
+  value: unknown,
+): Map<PathKey, {segment: Segment; value: unknown}> {
+  const out = new Map<PathKey, {segment: Segment; value: unknown}>();
+  if (value == null) return out;
+  for (const ref of desc.decompose(value)) {
+    out.set(keyOf([ref.key]), {segment: ref.key, value: ref.read(value)});
+  }
+  return out;
+}
+
+/** Whether two child maps hold the same set of keys. */
+function sameKeys(
+  a: ReadonlyMap<PathKey, unknown>,
+  b: ReadonlyMap<PathKey, unknown>,
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const k of a.keys()) if (!b.has(k)) return false;
+  return true;
 }
 
 /**
  * Find every dirty form in a value tree, extending the frozen baselines as new
  * collection elements appear.
  *
- * A form is dirty when its own value differs from its baseline (by its descriptor
- * rule) or when any descendant is dirty. A leaf within the initial structure
- * measures against its slot in `initialValue`; a leaf present in the value but
- * absent from the initial structure — a freshly grown collection element — has no
- * such slot, so its first-seen value is frozen as its baseline and added to the
- * returned frozen map. A grown element is therefore clean until later edited,
- * while its container is dirty in its own right (an array's length differs).
+ * A leaf is dirty when its own value differs from its baseline by its `equals`. A
+ * composite is dirty when any child is dirty or its key set differs from its
+ * baseline's (an element grown or dropped). A child present in the value but
+ * absent from the baseline structure — a freshly grown collection element — has
+ * no baseline to measure against, so its first-seen value is frozen as its
+ * baseline and added to the returned frozen map; it is therefore clean until
+ * later edited, while its container is dirty in its own right.
  *
  * @param value The current value tree.
  * @param initialValue The initial value tree.
@@ -71,10 +112,9 @@ export function walkValue(
 
   // `grown` marks a position with no counterpart in the initial structure — a
   // collection element appended past its parent's initial children. Such a
-  // position has no initial slot to measure against, so its first-seen value is
+  // position has no baseline to measure against, so its first-seen value is
   // frozen as its baseline (born clean, dirty once edited). The root is never
-  // grown, and a position present in the initial structure measures against its
-  // initial value even when that value is `undefined`.
+  // grown.
   const walk = (
     v: unknown,
     iv: unknown,
@@ -93,22 +133,25 @@ export function walkValue(
     if (Object.is(v, baseline)) return false; // unchanged subtree: O(1) prune
 
     const desc = descriptorAt(path);
-    const children = desc?.decompose?.(v) ?? [];
-    // The child segments the baseline holds. A child of `v` whose segment is
-    // absent here has grown past the initial structure.
-    const baselineSegments = new Set(
-      (baseline == null ? undefined : desc?.decompose?.(baseline))?.map(ref =>
-        keyOf([ref.segment]),
-      ) ?? [],
-    );
+    if (desc === undefined || !isComposite(desc)) {
+      const isDirty = !leafEquals(desc)(v, baseline);
+      if (isDirty) dirty.add(fk);
+      return isDirty;
+    }
+
+    const current = childrenByKey(desc, v);
+    const base = childrenByKey(desc, baseline);
     let childrenDirty = false;
-    for (const ref of children) {
-      const childGrown = !baselineSegments.has(keyOf([ref.segment]));
+    for (const [ck, {segment, value: childValue}] of current) {
+      const childGrown = !base.has(ck);
       if (
         walk(
-          ref.read(v),
-          childGrown ? undefined : ref.read(baseline),
-          childPath(path, ref.segment),
+          childValue,
+          // A grown child has no entry in `base`; the recursion freezes it and
+          // derives its own baseline, so the value passed here is a placeholder
+          // it overrides.
+          childGrown ? childValue : base.get(ck)!.value,
+          childPath(path, segment),
           childGrown,
         )
       ) {
@@ -116,7 +159,9 @@ export function walkValue(
       }
     }
 
-    const isDirty = !ownEquals(desc)(v, baseline) || childrenDirty;
+    // Own dirtiness of a composite is a change in its key set — an element grown
+    // or dropped since its baseline.
+    const isDirty = !sameKeys(current, base) || childrenDirty;
     if (isDirty) dirty.add(fk);
     return isDirty;
   };
@@ -129,57 +174,116 @@ export function walkValue(
  * within it contributes its current value where dirty against its baseline, or
  * the reset value where clean.
  *
- * @param oldValue The form's current value.
- * @param oldInitial The form's current initial value.
- * @param resetValue The value the form is being reset to.
+ * `initial` and `reset` are {@link Slot}s, so a position one tree lacks is marked
+ * absent rather than filled with a fabricated value. A form present in the
+ * current value but absent from the initial structure — a grown collection
+ * element — is a dirty addition kept whole; the walk re-freezes its baseline to
+ * its kept value. Because absent positions are settled by key-set membership, a
+ * leaf's `equals` is only ever called with two real values of its type.
+ *
+ * @param value The form's current value; always present, since only positions
+ *   present in the current value are recursed into.
+ * @param initial The form's initial value, absent when it grew past the initial
+ *   structure.
+ * @param reset The value the form is being reset to, absent where the reset does
+ *   not reach.
  * @param path The form's path.
  * @param descriptorAt Look up the descriptor registered at a path.
  * @param frozen The frozen baselines a grown element measures against.
  * @returns The merged value: the current value at each dirty form, the reset
  *   value at each clean one.
  */
-export function rebuildKeepDirty(
-  oldValue: unknown,
-  oldInitial: unknown,
-  resetValue: unknown,
+function rebuild(
+  value: unknown,
+  initial: Slot,
+  reset: Slot,
   path: Path,
   descriptorAt: DescriptorAt,
   frozen: ReadonlyMap<PathKey, unknown>,
 ): unknown {
   const desc = descriptorAt(path);
+  const fk = keyOf(path);
 
-  // A grown element's baseline is its frozen value, not the (absent) initial.
-  const baseline = frozen.has(keyOf(path))
-    ? frozen.get(keyOf(path))
-    : oldInitial;
-  const children = desc?.decompose?.(oldValue) ?? [];
+  // The baseline dirtiness is measured against: a grown element's frozen value,
+  // else its initial. A position with neither — present in the current value but
+  // absent from the initial structure and not yet frozen — is a brand-new
+  // addition with nothing to merge against, kept whole.
+  const baseline: Slot = frozen.has(fk) ? present(frozen.get(fk)) : initial;
+  if (!baseline.present) return value;
 
-  if (children.length === 0) {
-    // Leaf: keep its current value when dirty against its baseline, else reset.
-    return ownEquals(desc)(oldValue, baseline) ? resetValue : oldValue;
+  if (desc === undefined || !isComposite(desc)) {
+    // Leaf: keep its current value when dirty against its baseline; when clean,
+    // take the reset value, or keep the current value where the reset omits this
+    // position. `equals` sees two real values — never an absent one.
+    if (!leafEquals(desc)(value, baseline.value)) return value;
+    return reset.present ? reset.value : value;
   }
 
-  // An untouched subtree has nothing dirty to keep, so it takes the reset whole.
-  if (Object.is(oldValue, oldInitial)) return resetValue;
-
-  if (desc?.rebuild) {
-    return desc.rebuild(
-      oldValue,
-      oldInitial,
-      resetValue,
-      (segment, childOld, childInit, childReset) =>
-        rebuildKeepDirty(
-          childOld,
-          childInit,
-          childReset,
-          childPath(path, segment),
-          descriptorAt,
-          frozen,
-        ),
-    );
+  // An untouched subtree has nothing dirty to keep, so it takes the reset whole
+  // (or stays as it is where the reset omits it).
+  if (Object.is(value, baseline.value)) {
+    return reset.present ? reset.value : value;
   }
 
-  // A composite with no rebuild rule can't merge children, so it keeps or resets
-  // as a whole, comparing against its baseline by its own equality.
-  return ownEquals(desc)(oldValue, baseline) ? resetValue : oldValue;
+  const current = childrenByKey(desc, value);
+  const base = childrenByKey(desc, baseline.value);
+  const resetChildren = reset.present
+    ? childrenByKey(desc, reset.value)
+    : undefined;
+
+  // The rebuilt key set is the current one when the composite grew or shrank
+  // (its own structure is dirty and wins), else the reset's (its structure wins
+  // where the subtree kept its shape).
+  const ownDirty = !sameKeys(current, base);
+  const source = !ownDirty && resetChildren ? resetChildren : current;
+
+  const merged: [Segment, unknown][] = [];
+  for (const [ck, {segment, value: fromSource}] of source) {
+    const inCurrent = current.get(ck);
+    if (inCurrent === undefined) {
+      // Present only in the reset (the reset added it): take the reset value.
+      merged.push([segment, fromSource]);
+      continue;
+    }
+    const childInitial: Slot = base.has(ck)
+      ? present(base.get(ck)!.value)
+      : ABSENT;
+    const childReset: Slot = resetChildren?.has(ck)
+      ? present(resetChildren.get(ck)!.value)
+      : ABSENT;
+    merged.push([
+      inCurrent.segment,
+      rebuild(
+        inCurrent.value,
+        childInitial,
+        childReset,
+        childPath(path, inCurrent.segment),
+        descriptorAt,
+        frozen,
+      ),
+    ]);
+  }
+  return desc.build(merged);
+}
+
+/**
+ * Build the value a `keepDirtyValues` reset gives the subtree at `path`, from its
+ * current value, initial value, and reset value. See {@link rebuild}.
+ */
+export function rebuildKeepDirty(
+  value: unknown,
+  initialValue: unknown,
+  resetValue: unknown,
+  path: Path,
+  descriptorAt: DescriptorAt,
+  frozen: ReadonlyMap<PathKey, unknown>,
+): unknown {
+  return rebuild(
+    value,
+    present(initialValue),
+    present(resetValue),
+    path,
+    descriptorAt,
+    frozen,
+  );
 }

--- a/src/internal/use-store-slice.ts
+++ b/src/internal/use-store-slice.ts
@@ -12,7 +12,8 @@ import React from 'react';
 import type {FieldErrors} from '../field-errors';
 import {fieldErrorSetsDeepEqual} from '../field-errors';
 import {Form} from '../form';
-import {FormDescriptor} from './form-descriptor';
+import {ChildRef, Composite, FormDescriptor, Leaf} from './form-descriptor';
+import {Json, keyOf} from './path';
 import {Snapshot} from './store';
 
 /**
@@ -54,6 +55,40 @@ export function useFormSlice<T, S>(
   return React.useSyncExternalStore(store.subscribe, getSlice, getSlice);
 }
 
+/**
+ * Build a `Form` handle for each child of a composite from its `decompose` and
+ * `build`.
+ *
+ * Each child's read is its {@link ChildRef.read}; its write rebuilds the parent
+ * with that one child replaced — decompose the parent, swap the child at its
+ * key, build. Both run against the live parent value, so a handle stays correct
+ * as the value changes.
+ */
+export function childForms<T, Key extends Json, Child>(
+  form: Form<T>,
+  decompose: (value: T) => Iterable<ChildRef<T, Key, Child>>,
+  build: (children: Iterable<readonly [Key, Child]>) => T,
+  value: T,
+): {key: Key; control: Form<Child>}[] {
+  return [...decompose(value)].map(ref => {
+    const pathKey = keyOf([ref.key]);
+    return {
+      key: ref.key,
+      control: form.internal.child<Child>(ref.key, ref.read, (parent, child) =>
+        build(
+          [...decompose(parent)].map(
+            r =>
+              [
+                r.key,
+                keyOf([r.key]) === pathKey ? child : r.read(parent),
+              ] as const,
+          ),
+        ),
+      ),
+    };
+  });
+}
+
 /** Deep-equal comparison for error sets, for use as a slice `isEqual`. */
 export function errorSetsEqual(a: FieldErrors, b: FieldErrors): boolean {
   return fieldErrorSetsDeepEqual(a, b);
@@ -65,17 +100,19 @@ export function errorSetsEqual(a: FieldErrors, b: FieldErrors): boolean {
  * descriptor is re-registered after every commit, so a validator that closes
  * over fresh props replaces the one from the previous render.
  */
-export function useRegisterDescriptor<T>(
-  form: Form<T>,
-  descriptor: FormDescriptor<T> | null,
-): void {
+export function useRegisterDescriptor<
+  T,
+  Key extends Json = Json,
+  Child = unknown,
+>(form: Form<T>, descriptor: Leaf<T> | Composite<T, Key, Child> | null): void {
   // Re-register every render so a validator closing over fresh props replaces
   // the previous one. No cleanup here: re-registration overwrites in place, and
   // tearing the registration down between renders would unregister the form on
-  // every commit.
+  // every commit. The descriptor is stored with its container's key/element
+  // types erased, so cast to the erased form the store holds.
   React.useLayoutEffect(() => {
     if (!descriptor) return;
-    form.internal.register(descriptor);
+    form.internal.register(descriptor as unknown as FormDescriptor<T>);
   });
 
   // Unregister on a true unmount only — a `[]` effect, so it does not fire

--- a/src/use-field-array.ts
+++ b/src/use-field-array.ts
@@ -2,8 +2,9 @@ import React from 'react';
 
 import type {FieldErrors} from './field-errors';
 import {Form} from './form';
-import {FormDescriptor, Validator} from './internal/form-descriptor';
+import {ChildRef, Composite, Validator} from './internal/form-descriptor';
 import {
+  childForms,
   errorSetsEqual,
   useFormSlice,
   useRegisterDescriptor,
@@ -65,6 +66,18 @@ export type UseFieldArrayReturn<T> = {
   remove: (index: number) => void;
 };
 
+// The array as a container keyed by index. Hoisted to module scope (they close
+// over nothing) so the `fields` memo can depend on just [form, value] — inline
+// definitions would be new references each render and rebuild it every time.
+const decompose = <T>(value: T[]): ChildRef<T[], number, T>[] =>
+  value.map((_x, i) => ({key: i, read: a => a[i]}));
+
+const build = <T>(children: Iterable<readonly [number, T]>): T[] => {
+  const out: T[] = [];
+  for (const [i, x] of children) out[i] = x;
+  return out;
+};
+
 /**
  * Combine child forms into an array. The array is dirty when any child is dirty
  * or its current length differs from its initial length. A child appended past
@@ -79,42 +92,16 @@ export const useFieldArray = <T>({
   const value = useFormSlice(form, () => form.value, Object.is);
   const errors = useFormSlice(form, () => form.ownErrors, errorSetsEqual);
 
-  const descriptor: FormDescriptor<T[]> = {
+  const descriptor: Composite<T[], number, T> = {
+    decompose,
+    build,
     validate: validate as Validator<T[]> | undefined,
-    decompose: v => v.map((_x, i) => ({segment: i, read: a => a[i]})),
-    equals: (a, b) => a.length === b.length,
-    rebuild: (old, init, reset, recurse) => {
-      const lengthDirty = (init?.length ?? 0) !== old.length;
-      const targetLen = lengthDirty
-        ? old.length
-        : (reset?.length ?? old.length);
-      const out: T[] = [];
-      for (let i = 0; i < targetLen; i++) {
-        // An element past the reset value's length keeps its current value (the
-        // walk re-freezes its baseline to it).
-        out[i] =
-          reset && i < reset.length
-            ? (recurse(i, old[i], init?.[i], reset[i]) as T)
-            : old[i];
-      }
-      return out;
-    },
   };
   useRegisterDescriptor(form, descriptor);
 
   const fields = React.useMemo(
     () =>
-      value.map((_v, index) => ({
-        control: form.internal.child(
-          index,
-          arr => arr[index],
-          (arr, s) => {
-            const next = arr.slice();
-            next[index] = s;
-            return next;
-          },
-        ),
-      })),
+      childForms(form, decompose, build, value).map(({control}) => ({control})),
     [form, value],
   );
 

--- a/src/use-field-object.ts
+++ b/src/use-field-object.ts
@@ -1,8 +1,12 @@
 import React from 'react';
 
 import {Form} from './form';
-import {FormDescriptor} from './internal/form-descriptor';
-import {useFormSlice, useRegisterDescriptor} from './internal/use-store-slice';
+import {ChildRef, Composite} from './internal/form-descriptor';
+import {
+  childForms,
+  useFormSlice,
+  useRegisterDescriptor,
+} from './internal/use-store-slice';
 
 export type UseFieldObjectProps<O extends object> = {
   /** Parent control. */
@@ -19,6 +23,19 @@ export type UseFieldObjectReturn<O extends object> = {
   fields: {[P in keyof O]: UseFieldObjectField<O[P]>};
 };
 
+// The object as a container keyed by property name. Hoisted to module scope
+// (they close over nothing) so the `fields` memo can depend on just
+// [form, value] — inline definitions would be new references each render and
+// rebuild it every time.
+const decompose = <O extends {[prop: string]: unknown}>(
+  value: O,
+): ChildRef<O, string, unknown>[] =>
+  Object.keys(value).map(k => ({key: k, read: o => o[k]}));
+
+const build = <O extends {[prop: string]: unknown}>(
+  children: Iterable<readonly [string, unknown]>,
+): O => Object.fromEntries(children) as O;
+
 /**
  * Decompose an object form into one form per key. The object is dirty when
  * any child is dirty; it carries no validation of its own (children validate
@@ -27,24 +44,7 @@ export type UseFieldObjectReturn<O extends object> = {
 export const useFieldObject = <O extends {[prop: string]: unknown}>({
   control: form,
 }: UseFieldObjectProps<O>): UseFieldObjectReturn<O> => {
-  const descriptor: FormDescriptor<O> = {
-    // Iterate keys, not Object.entries: `read` projects from whatever object the
-    // walk passes it — the current value or the baseline — not from `v`.
-    decompose: v => Object.keys(v).map(k => ({segment: k, read: o => o[k]})),
-    // An object carries no own value beyond its children, so it is dirty only
-    // when a child is.
-    equals: () => true,
-    rebuild: (old, init, reset, recurse) => {
-      // The rebuilt object takes the reset value's key set: a key the reset
-      // adds appears, a key it drops is gone, a key in both is rebuilt from its
-      // child. With no reset value at this position, keep the current keys.
-      const out: Record<string, unknown> = {};
-      for (const k of Object.keys(reset ?? old)) {
-        out[k] = recurse(k, old[k], init?.[k], reset?.[k]);
-      }
-      return out as O;
-    },
-  };
+  const descriptor: Composite<O, string, unknown> = {decompose, build};
   useRegisterDescriptor(form, descriptor);
 
   // Re-render when this object's own value reference changes (a change anywhere
@@ -52,19 +52,13 @@ export const useFieldObject = <O extends {[prop: string]: unknown}>({
   const value = useFormSlice(form, () => form.value, Object.is);
 
   const fields = React.useMemo(() => {
-    const out = {} as {[P in keyof O]: UseFieldObjectField<O[P]>};
-    for (const key of Object.keys(value) as (keyof O & string)[]) {
-      out[key] = {
-        control: form.internal.child(
-          key,
-          o => o[key],
-          (o, s) => ({...o, [key]: s}),
-        ),
-      };
+    const out: Record<string, UseFieldObjectField<unknown>> = {};
+    for (const {key, control} of childForms(form, decompose, build, value)) {
+      out[key] = {control};
     }
-    return out;
-    // Each child form is a pure key projection; rebuild when the form
-    // identity or the value changes.
+    // The children are typed `unknown` in the shared derivation; an object's
+    // per-key value types are recovered by this return type.
+    return out as {[P in keyof O]: UseFieldObjectField<O[P]>};
   }, [form, value]);
 
   return {fields};

--- a/src/use-field.ts
+++ b/src/use-field.ts
@@ -1,6 +1,6 @@
 import type {FieldErrors} from './field-errors';
 import {Form} from './form';
-import {Equals, FormDescriptor, Validator} from './internal/form-descriptor';
+import {Equals, Leaf, Validator} from './internal/form-descriptor';
 import {
   errorSetsEqual,
   useFormSlice,
@@ -105,7 +105,7 @@ export const useField = <T>({
   // Contribute this leaf's validator and (non-default) equality. A pure-default
   // leaf registers nothing — the walk's reference compare is already its rule.
   const customEquals = equalsFn !== Object.is;
-  const descriptor: FormDescriptor<T> | null =
+  const descriptor: Leaf<T> | null =
     validate || customEquals
       ? {
           validate: validate as Validator<T> | undefined,


### PR DESCRIPTION
## What

`FormDescriptor` becomes a discriminated union `Leaf | Composite`:

- A **Leaf** is edited as one opaque value — it supplies `equals?` and `validate?`.
- A **Composite** is a container of child forms keyed by a JSON key — it supplies `decompose` (take a value apart into `(key, child)` pairs) and `build` (assemble one back). It has no own `equals`; its dirtiness is a change in its key set.

The core now owns dirtiness, the keep-dirty-reset merge, and the handling of absent positions (decided by key-set membership). Child `Form` handles derive from `decompose`/`build` through a shared helper, so a combinator declares its structure once instead of hand-writing per-child read/write lenses. `Key`/`Child` are precise at the authoring site and erased to `Json`/`unknown` where the library stores the descriptor.

## Why

A form's own equality could be handed `undefined` where its declared type promises a real value. To compare and merge value trees, the dirty and keep-dirty-reset walks used `undefined` as a stand-in for a position one tree held and another lacked — a grown collection element, or a key present in one tree but not another — and passed that stand-in to the form's equality. A form type whose equality assumes a real value (say a date comparator that parses its input) would then misbehave or throw.

Per ADR-0003 the core treats every value as opaque, so `undefined` must carry no special "absent" meaning. This recut makes absence structural — decided by key-set membership, never materialized as a value — so a combinator's `equals`/`build` only ever see real values of their type.

## Testing

- `yarn tsc:no-emit`, `yarn lint`, and `yarn test` all pass (112 tests).
- Added regression tests: a table (array of row objects) whose leaf equality throws on any non-declared-type input, grown past its initial value, then reset with `keepDirtyValues` — the case that exercised the bug, now green; plus the grown-then-edited and reset-grows-the-array variants.
